### PR TITLE
Enable host-specific options

### DIFF
--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -3,18 +3,27 @@ import io
 import copy
 from SubmitOptions import SubmitOptions
 
+LABEL_LENGTH = 12
+
 class SubmitAction() :
-  def __init__( self, name, options, defaultSubmitOptions = SubmitOptions(), parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
+
     self.name_          = name
+    self.label_            = "{0:<{1}}".format( "[{0}] ".format( self.name_ ), LABEL_LENGTH )
+    self.labelIndentation_ = "  "
+    self.labelLevel_       = 0
+    self.log( "Initializing" )
+    self.log_push()
+
     self.parent_        = parent
     self.options_       = options
-    self.submitOptions_ = copy.deepcopy( defaultSubmitOptions )
+    self.submitOptions_ = copy.deepcopy( defaultSubmitOptions ).selectHostSpecificSubmitOptions()
 
-    self.rootDir_       = rootDir
-    self.printDir_      = False
-    self.label_         = "{0:<{1}}".format( "[{0}] ".format( self.name_ ), 12 )
+    self.rootDir_          = rootDir
+    self.printDir_         = False
 
     self.parse()
+    self.log_pop()
 
   def log( self, *args, **kwargs ) :
     # https://stackoverflow.com/a/39823534
@@ -22,7 +31,12 @@ class SubmitAction() :
     print( *args, file=output, end="", **kwargs )
     contents = output.getvalue()
     output.close()
-    print( self.label_ + contents, flush=True )
+    print( self.label_ + self.labelIndentation_ * self.labelLevel_ + contents, flush=True )
+  
+  def log_push( self ) :
+    self.labelLevel_ += 1
+  def log_pop( self ) :
+    self.labelLevel_ -= 1
 
   def parseSpecificOptions( self ) :
     # Children should override this for their respective parse()
@@ -31,23 +45,28 @@ class SubmitAction() :
   def parse( self ) :
     key = "submit_options"
     if key in self.options_ :
-      self.submitOptions_.update( SubmitOptions( self.options_[ key ] ) )
+      self.submitOptions_.update( SubmitOptions( self.options_[ key ] ).selectHostSpecificSubmitOptions() )
 
     # Now call child parse
     self.parseSpecificOptions()
 
   def setWorkingDirectory( self ) :
+    self.log( "Preparing working directory" )
+    self.log_push()
+
     # Set directory
-    self.log( "Preparing to run from {0}".format( self.rootDir_ ) )
+    self.log( "Running from root directory {0}".format( self.rootDir_ ) )
 
     os.chdir( self.rootDir_ )
-    if self.printDir_ :
-      self.log( "Current directory : {0}".format( os.getcwd() ) )
-
     if self.submitOptions_.workingDirectory_ is not None :
       if self.printDir_ :
         self.log( "Setting working directory to {0}".format( self.submitOptions_.workingDirectory_ ) )
       os.chdir( self.submitOptions_.workingDirectory_ )
+    
+    if self.printDir_ :
+      self.log( "Current directory : {0}".format( os.getcwd() ) )
+
+    self.log_pop()
 
   def run( self ) :
     self.setWorkingDirectory()

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -7,7 +7,7 @@ from Step          import Step
 
 class Test( SubmitAction ):
   
-  def __init__( self, name, options, defaultSubmitOptions = SubmitOptions(), parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
     self.steps_         = {}
     super().__init__( name, options, defaultSubmitOptions, parent, rootDir )
 

--- a/.ci/example.json
+++ b/.ci/example.json
@@ -2,7 +2,13 @@
   "submit_options" :
   {
     "queue"     : "regular",
-    "timelimit" : "00:05:00"
+    "timelimit" : "00:05:00",
+    "cheyenne" :
+    {
+      "submission" : "PBS",
+      "queue"     : "regular",
+      "timelimit" : "00:05:00"
+    }
   },
   "test-id-0" :
   {
@@ -14,7 +20,15 @@
         { 
           "working_directory" : "./tests",
           "resources"         : "1:ncpus=1",
-          "timelimit"         : "00:01:00"
+          "timelimit"         : "00:01:00",
+          "cheyenne" :
+          {
+            "submission"        : "LOCAL"
+          },
+          "derecho" :
+          {
+            "submission" : "SLURM"
+          }
         },
         "command"      : "./test_0.sh",
         "arguments"    : [ "-ne", "\\nfoobar\\tbarbar\\n\\n" ]
@@ -24,7 +38,11 @@
         "submit_options" :
         { 
           "resources"         : "1:ncpus=1",
-          "timelimit"         : "00:05:00"
+          "timelimit"         : "00:05:00",
+          "cheyenne" :
+          {
+            "submission"        : "LOCAL"
+          }
         },
         "command"      : "tests/test_0.sh",
         "arguments"    : [ "Hello", "World!" ],
@@ -35,7 +53,11 @@
         "submit_options" :
         { 
           "working_directory" : "./tests",
-          "resources"         : "1:ncpus=1"
+          "resources"         : "1:ncpus=1",
+          "cheyenne" :
+          {
+            "submission"        : "LOCAL"
+          }
         },
         "command"      : "./test_0.sh",
         "arguments"    : [ "Final step" ],

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -99,7 +99,6 @@ def main() :
   options = Options()
   parser.parse_args( namespace=options )
   sa.LABEL_LENGTH = options.labelLength
-  print( sa.LABEL_LENGTH )
 
   opts = SubmitOptions()
   opts.account_    = options.account

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Run test 0
       run: |
         echo "Hello World!"
-        ./.ci/runner.py .ci/example.json test-id-0 -s LOCAL -d ..
+        ./.ci/runner.py .ci/example.json test-id-0 -d ..
     
     - name : Remove 'test' label
       if : ${{ github.event.label.name == 'test' }}


### PR DESCRIPTION
Various updates:
* Host-specific `submit_options` under normal `submit_options` field
* Configurable label length
* pop()/push() indentation logging
* Submit type as `submit_option` field
* Submit type override as cli option