### PR TITLE
HPC Sync Results and Argument Packs

### DIFF
--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -18,8 +18,10 @@ class Step( SubmitAction ):
     AFTEROK    = "afterok"
     AFTERNOTOK = "afternotok"
     AFTERANY   = "afterany"
-    # def __str__( self ) :
-    #   return str( self.value )
+    def __str__( self ) :
+      return str( self.value )
+    def __repr__( self ) :
+      return str( self.value )
     # @staticmethod
     # def fromString( s ) :
     #   return DependencyType[ s ]

--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -27,7 +27,7 @@ class Step( SubmitAction ):
     #   return DependencyType[ s ]
 
 
-  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
     self.submitted_ = False
     self.jobid_     = -1
     self.command_       = None
@@ -36,7 +36,7 @@ class Step( SubmitAction ):
     self.depSignOff_    = {} # steps we are dependent on will need to tell us when to go
     self.children_      = [] # steps that are dependent on us that we will need to sign off for
 
-    super().__init__( name, options, defaultSubmitOptions, parent, rootDir )
+    super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 
     self.printDir_ = True
 

--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -58,9 +58,7 @@ class Step( SubmitAction ):
 
     # Now set things manually
     self.submitOptions_.name_ = SUBMIT_NAME.format( test=self.parent_, step=self.name_ )
-    self.log( "Set submission name to {0}".format( self.submitOptions_.name_ ) )
 
-    self.log( "Validating submission options..." )
     valid, msg = self.submitOptions_.validate()
     if not valid :
       err = "Error: Invalid submission options [{msg}]\n{opts}".format( msg=msg, opts=self.submitOptions_ )
@@ -116,6 +114,7 @@ class Step( SubmitAction ):
     args, additionalArgs   = self.submitOptions_.format( print=self.log )
     workingDir = os.getcwd()
 
+    self.log( "Script : {0}".format( self.command_ ) )
     args.append( os.path.abspath( self.command_ ) )
     args.append( workingDir )
 
@@ -131,7 +130,7 @@ class Step( SubmitAction ):
 
     command = " ".join( [ arg if " " not in arg else "\"{0}\"".format( arg ) for arg in args ] )
     self.log( "Running command:" )
-    self.log( "\t{0}".format( command ) )
+    self.log( "  {0}".format( command ) )
 
     self.log(  "*" * 15 + "{:^15}".format( "START " + self.name_ ) + "*" * 15 + "\n" )
 
@@ -170,7 +169,7 @@ class Step( SubmitAction ):
       if self.submitOptions_.submitType_ != SubmitOptions.SubmissionType.LOCAL :
         content = output.getvalue().decode( 'utf-8' )
         output.close()
-        self.log( "Finding job ID in \"{0}\"".format( content ) )
+        self.log( "Finding job ID in \"{0}\"".format( content.rstrip() ) )
         # Find job id
         self.jobid_ = int( jobidRegex.match( content ).group(1) )
       else:

--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -8,7 +8,6 @@ import io
 from SubmitAction  import SubmitAction
 from SubmitOptions import SubmitOptions
 
-SUBMIT_NAME = "{test}.{step}"
 jobidRegex  = re.compile( r"(\d{5,})" )
 
 class Step( SubmitAction ):
@@ -57,7 +56,7 @@ class Step( SubmitAction ):
         self.dependencies_[ depStep ] = Step.DependencyType( depType )
 
     # Now set things manually
-    self.submitOptions_.name_ = SUBMIT_NAME.format( test=self.parent_, step=self.name_ )
+    self.submitOptions_.name_ = self.ancestry()
 
     valid, msg = self.submitOptions_.validate()
     if not valid :

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -12,8 +12,6 @@ class SubmitAction() :
     self.label_            = "{0:<{1}}".format( "[{0}] ".format( self.name_ ), so.LABEL_LENGTH )
     self.labelIndentation_ = "  "
     self.labelLevel_       = 0
-    self.log( "Initializing" )
-    self.log_push()
 
     self.parent_        = parent
     self.options_       = options
@@ -23,7 +21,6 @@ class SubmitAction() :
     self.printDir_         = False
 
     self.parse()
-    self.log_pop()
 
   def log( self, *args, **kwargs ) :
     # https://stackoverflow.com/a/39823534

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -21,6 +21,12 @@ class SubmitAction() :
     self.printDir_         = False
 
     self.parse()
+  
+  def ancestry( self ) :
+    if self.parent_ :
+      return "{0}.{1}".format( self.parent_, self.name_ )
+    else :
+      return self.name_
 
   def log( self, *args, **kwargs ) :
     # https://stackoverflow.com/a/39823534

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -6,10 +6,11 @@ from SubmitOptions import SubmitOptions
 LABEL_LENGTH = 12
 
 class SubmitAction() :
-  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
 
     self.name_          = name
-    self.label_            = "{0:<{1}}".format( "[{0}] ".format( self.name_ ), LABEL_LENGTH )
+    self.globalOpts_    = globalOpts # options passed in at CLI
+    self.label_            = "{0:<{1}}".format( "[{0}] ".format( self.name_ ), so.LABEL_LENGTH )
     self.labelIndentation_ = "  "
     self.labelLevel_       = 0
     self.log( "Initializing" )

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -2,8 +2,7 @@ import os
 import io
 import copy
 from SubmitOptions import SubmitOptions
-
-LABEL_LENGTH = 12
+import SubmitOptions as so
 
 class SubmitAction() :
   def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
@@ -46,7 +45,7 @@ class SubmitAction() :
   def parse( self ) :
     key = "submit_options"
     if key in self.options_ :
-      self.submitOptions_.update( SubmitOptions( self.options_[ key ] ).selectHostSpecificSubmitOptions() )
+      self.submitOptions_.update( SubmitOptions( self.options_[ key ], origin=self.name_ ).selectHostSpecificSubmitOptions(), print=self.log )
 
     # Now call child parse
     self.parseSpecificOptions()

--- a/.ci/SubmitOptions.py
+++ b/.ci/SubmitOptions.py
@@ -34,6 +34,7 @@ class SubmitOptions( ) :
     self.queue_             = None
     self.resources_         = None
     self.timelimit_         = None
+    self.wait_              = None
     
     # Should be set at test level 
     self.debug_             = None
@@ -116,6 +117,7 @@ class SubmitOptions( ) :
     if rhs.queue_               is not None : self.queue_             = rhs.queue_
     if rhs.resources_           is not None : self.resources_         = rhs.resources_
     if rhs.timelimit_           is not None : self.timelimit_         = rhs.timelimit_
+    if rhs.wait_                is not None : self.wait_              = rhs.wait_
     
     # Should be set at test level 
     # Never do this so children cannot override parent
@@ -192,20 +194,23 @@ class SubmitOptions( ) :
       submitDict    = { "submit" : "qsub",   "resources"  : "-l select={0}",
                         "name"   : "-N {0}", "dependency" : "-W depend={0}",
                         "queue"  : "-q {0}", "account"    : "-A {0}",
-                        "output" : "-j oe -o {0}.log",
-                        "time"   : "-l walltime={0}" }
+                        "output" : "-j oe -o {0}",
+                        "time"   : "-l walltime={0}",
+                        "wait"   : "-W block=true" }
     elif self.submitType_ == self.SubmissionType.SLURM :
       submitDict    = { "submit" : "sbtach", "resources"  : "--gres={0}",
                         "name"   : "-J {0}", "dependency" : "-d {0}",
                         "queue"  : "-p {0}", "account"    : "-A {0}",
                         "output" : "-j -o {0}",
-                        "time"   : "-t {0}" }
+                        "time"   : "-t {0}",
+                        "wait"   : "-W" }
     elif self.submitType_ == self.SubmissionType.LOCAL :
       submitDict    = { "submit" : "",       "resources"  : "",
                         "name"   : "",       "dependency" : "",
                         "queue"  : "",       "account"    : "",
-                        "output" : "-o {0}.log",
-                        "time"   : "" }
+                        "output" : "-o {0}",
+                        "time"   : "",
+                        "wait"   : "" }
 
     additionalArgs = []
     
@@ -239,6 +244,9 @@ class SubmitOptions( ) :
 
       if self.timelimit_ is not None :
         cmd.extend( submitDict[ "time" ].format( self.timelimit_ ).split( " " ) )
+      
+      if self.wait_ is not None :
+        cmd.extend( submitDict[ "wait" ].format( self.wait_ ).split( " " ) )
 
       # Set via test runner secrets
       if self.account_ is not None :
@@ -265,6 +273,7 @@ class SubmitOptions( ) :
               "queue"             : self.queue_,
               "resources"         : self.resources_,
               "timelimit"         : self.timelimit_,
+              "wait"              : self.wait_,
               "submitType"        : self.submitType_,
               "lockSubmitType"    : self.lockSubmitType_,
               "debug"             : self.debug_,

--- a/.ci/SubmitOptions.py
+++ b/.ci/SubmitOptions.py
@@ -98,7 +98,6 @@ class SubmitOptions( ) :
       if not self.lockSubmitType_ :
         self.submitType_ = SubmitOptions.SubmissionType( self.submit_[ key ] )
 
-        # raise Exception(1)
 
     # Process all other keys as host-specific options
     for key, value in self.submit_.items() :

--- a/.ci/SubmitOptions.py
+++ b/.ci/SubmitOptions.py
@@ -3,6 +3,20 @@ import socket
 
 from enum import Enum
 
+# https://stackoverflow.com/a/3233356
+import collections.abc
+
+LABEL_LENGTH = 12
+
+# Update mapping dest with source
+def recursiveUpdate( dest, source ):
+  for k, v in source.items():
+    if isinstance( v, collections.abc.Mapping ):
+      dest[k] = recursiveUpdate( dest.get( k, {} ), v )
+    else:
+      dest[k] = v
+  return dest
+
 class SubmitOptions( ) :
   class SubmissionType( Enum ):
     PBS   = "PBS"
@@ -11,8 +25,10 @@ class SubmitOptions( ) :
 
     def __str__( self ) :
       return self.value
+  
+  ARGUMENTS_ORIGIN_KEY = "arguments_origin"
 
-  def __init__( self, optDict={}, isHostSpecific=False, lockSubmitType=False ) :
+  def __init__( self, optDict={}, isHostSpecific=False, lockSubmitType=False, origin=None ) :
     self.submit_            = optDict
     self.workingDirectory_  = None
     self.queue_             = None
@@ -31,12 +47,15 @@ class SubmitOptions( ) :
     self.name_             = None
     self.dependencies_     = None
 
+    # Should normally be restricted to host-specific options
+    self.arguments_        = {}
+
     # Allow host-specific submit options
     self.isHostSpecific_      = isHostSpecific
     self.hostSpecificOptions_ = {}
-    self.parse()
+    self.parse( origin=origin )
 
-  def parse( self, log=False ):
+  def parse( self, log=False, origin=None ):
     submitKeys = []
 
     key = "working_directory"
@@ -59,6 +78,18 @@ class SubmitOptions( ) :
     if key in self.submit_ :
       self.timelimit_ = self.submit_[ key ]
     
+    key = "wait"
+    submitKeys.append( key )
+    if key in self.submit_ :
+      self.wait_ = self.submit_[ key ]
+    
+    key = "arguments"
+    submitKeys.append( key )
+    if key in self.submit_ :
+      self.arguments_ = self.submit_[ key ]
+      if origin is not None :
+        self.arguments_[ SubmitOptions.ARGUMENTS_ORIGIN_KEY ] = { argKey : origin for argKey in self.arguments_.keys() }
+    
     # Allow parsing of per-action submission
     key = "submission"
     submitKeys.append( key )
@@ -74,13 +105,13 @@ class SubmitOptions( ) :
         if not self.isHostSpecific_ :
           # ok to parse
           self.hostSpecificOptions_[ key ] = SubmitOptions( value, isHostSpecific=True )
-          self.hostSpecificOptions_[ key ].parse()
+          self.hostSpecificOptions_[ key ].parse( origin=origin )
         else :
           print( "Warning: Host-specific options cannot have sub-host-specific options" )
 
 
   # Updates and overrides current with values from rhs if they exist
-  def update( self, rhs ) :
+  def update( self, rhs, print=print ) :
     if rhs.workingDirectory_    is not None : self.workingDirectory_ = rhs.workingDirectory_
     if rhs.queue_               is not None : self.queue_             = rhs.queue_
     if rhs.resources_           is not None : self.resources_         = rhs.resources_
@@ -98,10 +129,13 @@ class SubmitOptions( ) :
     # Should be set via the step
     if rhs.name_                is not None : self.name_             = rhs.name_
     if rhs.dependencies_        is not None : self.dependencies_     = rhs.dependencies_
-    if rhs.hostSpecificOptions_             : self.hostSpecificOptions_.update( rhs.hostSpecificOptions_ )
+
+    # These are both dictionaries
+    if rhs.arguments_                       : recursiveUpdate( self.arguments_, rhs.arguments_ )
+    if rhs.hostSpecificOptions_             : recursiveUpdate( self.hostSpecificOptions_, rhs.hostSpecificOptions_ )
 
     # This keeps things consistent but should not affect anything
-    self.submit_.update( rhs.submit_ )
+    recursiveUpdate( self.submit_, rhs.submit_ )
     self.parse( log=True )
   
   # Check non-optional fields
@@ -144,8 +178,11 @@ class SubmitOptions( ) :
       currentSubmitOptions.update( self.hostSpecificOptions_[ hostSpecificOptKey ] )
 
     return currentSubmitOptions
+  
+  def getOutputFilename( self ) :
+    return "{0}.log".format( self.name_ )
 
-  def format( self ) :
+  def format( self, print=print ) :
     # Why this can't be with the enum
     # https://stackoverflow.com/a/45716067
     # Why this can't be a dict value of the enum
@@ -170,9 +207,26 @@ class SubmitOptions( ) :
                         "output" : "-o {0}.log",
                         "time"   : "" }
 
+    additionalArgs = []
+    
+    if self.arguments_ :
+      # Format them and pass them out in alphabetical order
+      longestPack = len( max( [ key for key in self.arguments_.keys() if key != SubmitOptions.ARGUMENTS_ORIGIN_KEY ], key=len ) )
+      for key, value in sorted( self.arguments_.items() ) :
+        if key != SubmitOptions.ARGUMENTS_ORIGIN_KEY :
+          print( 
+                "From {origin:<{length}} adding arguments pack {key:<{packlength}} : {val}".format(
+                                                                                        origin=self.arguments_[SubmitOptions.ARGUMENTS_ORIGIN_KEY][key],
+                                                                                        length=LABEL_LENGTH,
+                                                                                        packlength=longestPack + 2,
+                                                                                        key="'{0}'".format( key ),
+                                                                                        val=value
+                                                                                        )
+                )
+          additionalArgs.extend( value )
 
     if self.submitType_ == self.SubmissionType.LOCAL :
-      return []
+      return [], additionalArgs
     else :
       cmd = [ submitDict[ "submit" ] ]
 
@@ -193,7 +247,7 @@ class SubmitOptions( ) :
       # Set via step
       if self.name_ is not None :
         cmd.extend( submitDict[ "name"   ].format( self.name_ ).split( " " ) )
-        cmd.extend( submitDict[ "output" ].format( self.name_ ).split( " " ) )
+        cmd.extend( submitDict[ "output" ].format( self.getOutputFilename() ).split( " " ) )
 
 
       if self.dependencies_ is not None :
@@ -203,7 +257,7 @@ class SubmitOptions( ) :
         # Extra bit to delineate command + args
         cmd.append( "--" )
 
-      return cmd
+      return cmd, additionalArgs
 
   def __str__( self ) :
     output = {
@@ -217,6 +271,7 @@ class SubmitOptions( ) :
               "account"           : self.account_,
               "name"              : self.name_,
               "dependencies"      : self.dependencies_,
+              "arguments"         : self.arguments_,
               "union_parse"       : self.submit_ }
 
     return str( output )

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from SubmitAction  import SubmitAction
 from SubmitOptions import SubmitOptions

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -20,7 +20,7 @@ class Test( SubmitAction ):
         self.log( "Keyword 'results' not allowed as step name, reason: reserved" )
         exit( 1 )
       for stepname, stepDict in self.options_[ key ].items() :
-        self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.name_, rootDir=self.rootDir_ )
+        self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
     
     # Now that steps are fully parsed, attempt to organize dependencies
     Step.sortDependencies( self.steps_ )
@@ -87,7 +87,7 @@ class Test( SubmitAction ):
                                         resultsDict,
                                         self.submitOptions_,
                                         self.globalOpts_,
-                                        parent=self.name_,
+                                        parent=self.ancestry(),
                                         rootDir=self.rootDir_
                                         )
         self.log( "Rescanning dependencies under test {0}...".format( self.name_ ) )

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -7,16 +7,16 @@ from Step          import Step
 
 class Test( SubmitAction ):
   
-  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
     self.steps_         = {}
-    super().__init__( name, options, defaultSubmitOptions, parent, rootDir )
+    super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 
   def parseSpecificOptions( self ) :
 
     key = "steps"
     if key in self.options_ :
       for stepname, stepDict in self.options_[ key ].items() :
-        self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, parent=self.name_, rootDir=self.rootDir_ )
+        self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.name_, rootDir=self.rootDir_ )
     
     # Now that steps are fully parsed, attempt to organize dependencies
     Step.sortDependencies( self.steps_ )

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -16,6 +16,9 @@ class Test( SubmitAction ):
 
     key = "steps"
     if key in self.options_ :
+      if key == "results" :
+        self.log( "Keyword 'results' not allowed as step name, reason: reserved" )
+        exit( 1 )
       for stepname, stepDict in self.options_[ key ].items() :
         self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.name_, rootDir=self.rootDir_ )
     
@@ -24,6 +27,8 @@ class Test( SubmitAction ):
 
 
   def executeAction( self ) :
+    self.setupResultsStep()
+
     steps = []
     while len( steps ) != len( self.steps_ ) :
       for step in self.steps_.values() :
@@ -34,3 +39,92 @@ class Test( SubmitAction ):
       self.log( "Checking remaining steps..." )
 
     self.log( "No remaining steps, test submission complete" )
+
+    self.postProcessResults( steps )
+
+  def setupResultsStep( self ) :
+    # Do we need to add a results step?
+    if self.globalOpts_.nowait :
+      self.log( "No waiting for HPC submissions requested, skipping results sync" )
+      return
+    
+    self.log( "Checking if results sync step required" )
+    self.log_push()
+    # Get all current steps submission type
+    subs = [ step.submitOptions_.submitType_ for step in self.steps_.values() if step.submitOptions_.submitType_ != SubmitOptions.SubmissionType.LOCAL ]
+    
+    if len( subs ) > 1 :
+      PBS_MIN_RES   = "1:ncpus=1"
+      SLURM_MIN_RES = "cpu:1"
+      res = None
+      submitType = None
+      if SubmitOptions.SubmissionType.PBS in subs :
+        res = PBS_MIN_RES
+        submitType = SubmitOptions.SubmissionType.PBS
+      else : # SLURM
+        res = SLURM_MIN_RES
+        submitType = SubmitOptions.SubmissionType.SLURM
+      
+      
+      if res is not None :
+        self.log( "Final results job being created to wait for all jobs complete" )
+        
+        deps = { stepname : "afterany" for stepname in self.steps_.keys() }
+        resultsDict = {
+                        "submit_options" :
+                        {
+                          "resources" : res,
+                          "wait"      : True,
+                          "submission": submitType
+                        },
+                        "command" : os.path.dirname( os.path.abspath( sys.argv[0] ) ) + "/" + "results.sh",
+                        "dependencies" : deps
+                      }
+
+        # Quickly add this step
+        self.steps_[ "results" ] = Step(
+                                        'results',
+                                        resultsDict,
+                                        self.submitOptions_,
+                                        self.globalOpts_,
+                                        parent=self.name_,
+                                        rootDir=self.rootDir_
+                                        )
+        self.log( "Rescanning dependencies under test {0}...".format( self.name_ ) )
+        Step.sortDependencies( self.steps_ )
+        self.log( "Step results dependencies : {0}".format( self.steps_[ "results" ].dependencies_ ) )
+
+    elif len( subs ) == 1 :
+      self.log( "Only one HPC submission exists, setting that job to wait" )
+      for stepname, step in self.steps_.items() :
+        if step.submitOptions_.submitType_ != SubmitOptions.SubmissionType.LOCAL :
+          step.submitOptions_.wait_ = True
+          self.log( "Forcing {step} to wait for job completion".format( step=stepname ) )
+    else :
+      self.log( "No HPC submissions, no results job added" )
+
+    self.log_pop()
+
+  def postProcessResults( self, stepOrder ) :
+    # Do we need to post-process HPC submission files
+    if not self.globalOpts_.nopost :
+      if self.globalOpts_.nowait :
+        self.log( "Post-processing requires waiting for HPC submissions, skipped" )
+      else :
+        # Get all current steps submission type
+        subs = [ step.submitOptions_.submitType_ for step in self.steps_.values() ]
+
+        if not ( SubmitOptions.SubmissionType.PBS in subs or SubmitOptions.SubmissionType.SLURM in subs ) :
+          self.log( "No HPC submissions, no results to post-process" )
+          return
+        else :
+          # We go through the steps in the order submitted
+          self.log( "Outputting results..." )
+          self.log_push()
+
+          for stepname in stepOrder :
+            if stepname != "results" and self.steps_[ stepname ].submitOptions_ != SubmitOptions.SubmissionType.LOCAL :
+              self.steps_[ stepname ].postProcessResults()
+          
+          self.log_pop()
+

--- a/.ci/results.sh
+++ b/.ci/results.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "HPC Results ready"

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -40,7 +40,12 @@ def getOptionsParser():
 
                                                             Scripts running from this framework should always take at least one 
                                                             prefix arguments ($1) before any other arguments which will be the 
-                                                            working directory that should immediate be cd'ed to
+                                                            working directory that should immediate be cd'ed to.
+
+                                                            Likewise, if a script is submitted to an HPC run (non-LOCAL) and requests automatic
+                                                            post-processing, this will always assume failure unless the <KEY PHRASE> is at the end
+                                                            of the logfile. Thus, scripts running in this mode should assume the same and only output
+                                                            success <KEY PHRASE> when completing successfully AT THE VERY END AS THE LAST LINE.
                                                             """ ),
                                   formatter_class=argparse.RawTextHelpFormatter
                                   )
@@ -85,6 +90,37 @@ def getOptionsParser():
                       help="Length of left-justify label string [file|test|step]",
                       type=int,
                       default=12
+                      )
+  parser.add_argument( 
+                      "-nf", "--nofatal",
+                      dest="nofatal",
+                      help="Force continuation of test even if scripts' return code is error",
+                      default=False,
+                      const=True,
+                      action='store_const'
+                      )
+  parser.add_argument( 
+                      "-nw", "--nowait",
+                      dest="nowait",
+                      help="HPC submission - Don't wait for all jobs completion, which is done via a final .results job with dependency on all jobs",
+                      default=False,
+                      const=True,
+                      action='store_const'
+                      )
+  parser.add_argument( 
+                      "-np", "--nopost",
+                      dest="nopost",
+                      help="HPC submission - Don't post-process log files for results using <KEY PHRASE>",
+                      default=False,
+                      const=True,
+                      action='store_const'
+                      )
+  parser.add_argument(
+                      "-k", "--key",
+                      dest="key",
+                      help="Post-processing <KEY PHRASE> regex to signal a script logfile passed successfully. Assumed failed if not last line of script logfile. (default : \"%(default)s\")",
+                      default="TEST ((?:\w+|[.-])+) PASS",
+                      type=str
                       )
 
   return parser

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -18,7 +18,7 @@ class Suite( SubmitAction ) :
   def parseSpecificOptions( self ) :
     for test, testDict in self.options_.items() :
       if test != "submit_options" :
-        self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.name_, rootDir=self.rootDir_ )
+        self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
 
   def run( self, test ) :
     self.setWorkingDirectory()
@@ -92,6 +92,13 @@ def getOptionsParser():
                       default=12
                       )
   parser.add_argument( 
+                      "-g", "--global",
+                      dest="globalPrefix",
+                      help="Global prefix to name step submission names, added as <PREFIX>.<rest of name>",
+                      type=str,
+                      default=None
+                      )
+  parser.add_argument( 
                       "-nf", "--nofatal",
                       dest="nofatal",
                       help="Force continuation of test even if scripts' return code is error",
@@ -158,12 +165,16 @@ def main() :
   # Go up one to get repo root - change this if you change the location of this script
   root  = os.path.abspath( os.path.dirname( options.testsConfig ) + "/" + options.dirOffset )
   print( "Root directory is : {0}".format( root ) )
-  
+
+  # Construct simplified name 
+  basename = os.path.splitext( os.path.basename( options.testsConfig ) )[0]
+
   testSuite = Suite( 
-                    options.testsConfig,
+                    basename,
                     json.load( fp ),
                     opts,
                     options,
+                    parent=options.globalPrefix,
                     rootDir=root
                     )
 

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -98,7 +98,7 @@ def main() :
   parser  = getOptionsParser()
   options = Options()
   parser.parse_args( namespace=options )
-  sa.LABEL_LENGTH = options.labelLength
+  so.LABEL_LENGTH = options.labelLength
 
   opts = SubmitOptions()
   opts.account_    = options.account

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -7,18 +7,18 @@ import inspect
 from Test          import Test
 from SubmitOptions import SubmitOptions
 from SubmitAction  import SubmitAction
-import SubmitAction as sa
+import SubmitOptions as so
 
 class Suite( SubmitAction ) :
-  def __init__( self, name, options, defaultSubmitOptions, parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
     self.tests_ = {}
-    super().__init__( name, options, defaultSubmitOptions, parent, rootDir )
+    super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 
 
   def parseSpecificOptions( self ) :
     for test, testDict in self.options_.items() :
       if test != "submit_options" :
-        self.tests_[ test ] = Test( test, testDict, self.submitOptions_, parent=self.name_, rootDir=self.rootDir_ )
+        self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.name_, rootDir=self.rootDir_ )
 
   def run( self, test ) :
     self.setWorkingDirectory()
@@ -127,6 +127,7 @@ def main() :
                     options.testsConfig,
                     json.load( fp ),
                     opts,
+                    options,
                     rootDir=root
                     )
 


### PR DESCRIPTION
Features
* Dynamic in-situ results collection step blocking test completion for multi-HPC submission tests
* Single HPC submission tests force blocking on individual test
* Post-processing with <key phrase> denoting pass enabled
* Hierarchical argument packs added to SubmitOptions/"submit_options" and thus also available in host-specific options
* Non-fatal, non-waiting, non-results processing options available at CLI

Bug fixes/Enhancements:
* Ancestry-based naming of HPC step submission naming
* Improved logging experience for errors
* Report log file used for HPC submissions
* Global options set by argparse available at all levels now (Suite, Test, Step - all SubmitAction)