### PR TITLE
Argument Pack Pattern Matching

### DIFF
--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -166,7 +166,8 @@ def main() :
 
   fp    = open( options.testsConfig, 'r' )
   # Go up one to get repo root - change this if you change the location of this script
-  root  = os.path.abspath( os.path.dirname( options.testsConfig ) + "/" + options.dirOffset )
+  testDir = os.path.dirname( options.testsConfig )
+  root  = os.path.abspath( testDir if testDir else "."  + "/" + options.dirOffset )
   print( "Root directory is : {0}".format( root ) )
 
   # Construct simplified name 


### PR DESCRIPTION
Regex-based argument pack pattern matching with special syntax `<regex>::<name>` when naming a specific argument pack. To later overwrite an argument pack, they must match EXACTLY, simply using `<name>` will assume a global named argument pack which is different. Basically it is a dumb string dictionary under the hood. You have been warned