### PR TITLE
Revise nofatal

### DIFF
--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -222,7 +222,7 @@ class Step( SubmitAction ):
             )
       self.log( msg )
 
-      if not self.globalOpts_.nofatal :
+      if self.submitOptions_.submitType_ != SubmissionType.LOCAL and not self.globalOpts_.nofatal :
         raise Exception( msg )
     
     # If we get this far sign off
@@ -294,7 +294,7 @@ class Step( SubmitAction ):
     except : 
       msg = "Logfile {0} does not exist, did submission fail?".format( self.logfile_ )
       self.log( msg )
-      raise Exception( msg )
+      return success, msg
 
     try :
       self.log( "Checking last line for success <KEY PHRASE> of format '{0}'".format( self.globalOpts_.key ) )

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -27,8 +27,9 @@ class Test( SubmitAction ):
     key = "steps"
     if key in self.options_ :
       if key == "results" :
-        self.log( "Keyword 'results' not allowed as step name, reason: reserved" )
-        exit( 1 )
+        msg = "Keyword 'results' not allowed as step name, reason: reserved"
+        self.log( msg )
+        raise Exception( msg )
       for stepname, stepDict in self.options_[ key ].items() :
         self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
     
@@ -132,9 +133,6 @@ class Test( SubmitAction ):
         json.dump( stepsLog, f, indent=2 )
 
       errs = self.reportErrs( stepsLog )
-
-      if errs and not self.globalOpts_.nofatal :
-        exit( 1 )
 
       self.log_pop()
     return not errs

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -359,8 +359,6 @@ def runSuite( options ) :
     # We don't have an account && we are not running local
     err = "Error: No account provided for non-local run."
     print( err )
-    if options.nofatal :
-      return ( False, options.tests )
     else :
       raise Exception( err )
 
@@ -503,7 +501,7 @@ def getOptionsParser():
   parser.add_argument( 
                       "-nf", "--nofatal",
                       dest="nofatal",
-                      help="Force continuation of test even if scripts' return code is error",
+                      help="HPC submission - Force continuation of test even if submission return code is error",
                       default=False,
                       const=True,
                       action='store_const'

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -359,8 +359,7 @@ def runSuite( options ) :
     # We don't have an account && we are not running local
     err = "Error: No account provided for non-local run."
     print( err )
-    else :
-      raise Exception( err )
+    raise Exception( err )
 
   fp    = open( options.testsConfig, 'r' )
   # Go up one to get repo root - change this if you change the location of this script

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -571,7 +571,10 @@ def main() :
   options = Options()
   parser.parse_args( namespace=options )
 
-  runSuite( options )
+  success, tests, logs = runSuite( options )
+
+  if not success :
+    exit( 1 )
 
 if __name__ == '__main__' :
   main()

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -324,7 +324,7 @@ class Suite( SubmitAction ) :
   def run( self, tests ) :
     for test in tests :
       if test not in self.tests_.keys() :
-        msg = "Error: no test named '{0}'".format( tests )
+        msg = "Error: no test named '{0}'".format( test )
         self.log( msg )
         raise Exception( msg )
 


### PR DESCRIPTION
Nofatal now only applies to HPC submissions to continue submissions even if HPC scheduling failed. Probably will never be used