### PR TITLE
Multithread steps

### DIFF
--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -28,7 +28,7 @@ class Step( SubmitAction ):
   def scope( self ) :
     return "step"
 
-  def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
+  def __init__( self, name, options, defaultSubmitOptions, globalOpts, lock, notifier, parent = "", rootDir = "./" ) :
     self.submitted_ = False
     self.jobid_     = None
     self.retval_    = None
@@ -39,6 +39,8 @@ class Step( SubmitAction ):
     self.children_      = [] # steps that are dependent on us that we will need to sign off for
     # DO NOT MODIFY THIS UNLESS YOU UNDERSTAND THE IMPLICATIONS
     self.addWorkingDirArg_ = True
+    self.lock_          = lock
+    self.wakeTest_      = notifier
 
     super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 

--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -114,11 +114,17 @@ class Step( SubmitAction ):
     if self.submitOptions_.lockSubmitType_ and "submission" in self.submitOptions_.submit_ :
       self.log( "{{ '{0}' : {1} }} overridden by cli".format( "submission", self.submitOptions_.submit_[ "submission" ] ) )
 
+  def prepExecuteAction( self ) :
+    # We are about to execute - these are the first to happen
+    # Acquire the lock until we have finished submitting our step
+    self.lock_.acquire()
+    # Immediately consider ourselves submitted, thus not runnable anymore
+    self.submitted_ = True
+
   def executeAction( self ) :
     # Do submission logic....
     self.log( "Submitting step {0}...".format( self.name_ ) )
     self.log_push()
-    self.submitted_ = True
     self.executeInfo()
   
     redirect = ( self.submitOptions_.submitType_ == SubmissionType.LOCAL and not self.globalOpts_.inlineLocal )
@@ -163,12 +169,24 @@ class Step( SubmitAction ):
       else :
         # Just keep in memory as a string
         output = io.BytesIO()
-      proc = subprocess.Popen(
-                              args,
-                              stdin =subprocess.PIPE,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT
-                              )
+      try :
+        proc = subprocess.Popen(
+                                args,
+                                stdin =subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT
+                                )
+      except Exception as e :
+        # If we fail, we need to tell our parent test :(
+        self.wakeTest_.release()
+        # And release other lock
+        self.lock_.release()
+        # and propagate the exception
+        raise e
+
+      # We are at this point only reading in the step running, no need to hold others up
+      self.lock_.release()
+
       for c in iter( lambda: proc.stdout.read(1), b"" ):
         # Always store in logfile
         logfileOutput.write( c.decode( 'utf-8', 'replace' ) )
@@ -189,6 +207,8 @@ class Step( SubmitAction ):
       self.log( "Doing dry-run, no ouptut" )
       self.retval_ = 0
       output       = "12345"
+      self.lock_.release()
+
 
     print( "\n", flush=True, end="" )
     self.log(  "*" * 15 + "{:^15}".format( "STOP " + self.name_ ) + "*" * 15 )
@@ -223,15 +243,22 @@ class Step( SubmitAction ):
 
       if self.submitOptions_.submitType_ != SubmissionType.LOCAL and not self.globalOpts_.nofatal :
         raise Exception( msg )
-    
+
     # If we get this far sign off
     if self.children_ :
       self.log( "Notifying children..." )
+      # Step is done and we need to write to other steps so re-acquire the lock for safe writing 
+      # ALSO do this after all error handling so we know we are safe to lock without leaving us in a catatonic state
+      self.lock_.acquire()
       self.notifyChildren( )
+      self.lock_.release()
 
     self.log_pop()
     
     self.log( "Finished submitting step {0}\n".format( self.name_ ) )
+
+    # Tell our test to wake up and check any changes to states
+    self.wakeTest_.release()
 
   def notifyChildren( self ) :
     if self.children_ :

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -81,8 +81,12 @@ class SubmitAction( ) :
       self.log( "Current directory : {0}".format( os.getcwd() ) )
 
     self.log_pop()
+  
+  def prepExecuteAction( self ) :
+    pass
 
   def run( self ) :
+    self.prepExecuteAction()
     self.setWorkingDirectory()
     return self.executeAction()
   

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -35,7 +35,16 @@ class Test( SubmitAction ):
         self.log( msg )
         raise Exception( msg )
       for stepname, stepDict in self.options_[ key ].items() :
-        self.steps_[ stepname ] = Step( stepname, stepDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
+        self.steps_[ stepname ] = Step(
+                                        stepname,
+                                        stepDict,
+                                        self.submitOptions_,
+                                        self.globalOpts_,
+                                        self.multiStepLock_,
+                                        self.stepNotifier_,
+                                        parent=self.ancestry(),
+                                        rootDir=self.rootDir_
+                                        )
     
     # Now that steps are fully parsed, attempt to organize dependencies
     Step.sortDependencies( self.steps_ )

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -4,13 +4,15 @@ import json
 import time
 from collections import OrderedDict
 from datetime import timedelta
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 from SubmitAction  import SubmitAction
 from SubmitOptions import SubmitOptions, SubmissionType
 from Step          import Step
 
-HPC_DELAY_PERIOD_SECONDS = 60
-HPC_POLL_PERIOD_SECONDS = 120
+HPC_DELAY_PERIOD_SECONDS =  60
+HPC_POLL_PERIOD_SECONDS  = 120
 
 class Test( SubmitAction ):
 
@@ -20,6 +22,8 @@ class Test( SubmitAction ):
   def __init__( self, name, options, defaultSubmitOptions, globalOpts, parent = "", rootDir = "./" ) :
     self.steps_         = {}
     self.waitResults_    = False
+    self.multiStepLock_  = threading.Lock()
+    self.stepNotifier_   = threading.Semaphore( 0 ) # Starts unable to acquire
     super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 
   def parseSpecificOptions( self ) :

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -62,16 +62,13 @@ class Test( SubmitAction ):
       for step in self.steps_.values() :
         if step.runnable() and step.name_ not in stepsAlreadyRun :
           stepsAlreadyRun[ step.name_ ] = submittedStep = executor.submit( step.run )
-          # Add a callback to facilitate any errors
-          # submittedStep.add_done_callback( self.stepComplete )
-          # stepsAlreadyRun.append( step.name_ )
 
       # We have submitted all runnable steps for the current phase, and there is no guarantee
       # that all these steps need to complete at the same time so DO NOT WAIT for all
       # results, but instead patiently wait for one of the submitted steps to wake us up
       # and then check if any of our runnable states has changed, obviously if no steps
       # have completed between our last check and an arbitrary time later then no runnable states
-      # will have changed either (THIS DOES NOT WORK WELL WITH LOCAL SUBMISSION AND AFTER ONLY DEPENDENCY)
+      # will have changed either (THIS DOES NOT WORK WELL WITH LOCAL SUBMISSION AND "AFTER" ONLY DEPENDENCY)
       self.stepNotifier_.acquire()
 
       # Make sure anything that woke us up was okay

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -395,6 +395,11 @@ def runSuite( options ) :
     err = "Error: No account provided for non-local run."
     print( err )
     raise Exception( err )
+
+  if options.inlineLocal and options.threadpool > 1 :
+    print( "Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)" )
+    options.threadpool = 1
+
   # Quickly convert to abs path
   options.testsConfig = os.path.abspath( options.testsConfig )
 
@@ -568,7 +573,14 @@ def getOptionsParser():
   parser.add_argument(
                       "-p", "--pool",
                       dest="pool",
-                      help="Threadpool size when running multiple tests, if serial is desired set to 1",
+                      help="Process pool size when running multiple tests, if serial test runs are desired set to 1",
+                      default=4,
+                      type=int
+                      )
+  parser.add_argument(
+                      "-tp", "--threadpool",
+                      dest="threadpool",
+                      help="Threadpool size when running multiple steps, if serial step runs are desired set to 1",
                       default=4,
                       type=int
                       )

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -608,7 +608,7 @@ def getOptionsParser():
   #                     )
 
   parser.add_argument(
-                      "-fc", "--forceSingle",
+                      "-fs", "--forceSingle",
                       dest="forceSingle",
                       help="Force multi-testing to run in single-process mode",
                       default=False,

--- a/.github/workflows/regtests.yml
+++ b/.github/workflows/regtests.yml
@@ -62,6 +62,14 @@ jobs:
     - name: Run test 00_10
       run: |
         ./tests/00_*/00_10*
+    
+    - name: Run test 02_00
+      run: |
+        ./tests/00_*/02_00*
+
+    - name: Run test 02_01
+      run: |
+        ./tests/00_*/02_01*
 
   removeLabel:
     if : ${{ !cancelled() && github.event.label.name == 'test' }}

--- a/.github/workflows/regtests.yml
+++ b/.github/workflows/regtests.yml
@@ -65,11 +65,11 @@ jobs:
     
     - name: Run test 02_00
       run: |
-        ./tests/00_*/02_00*
+        ./tests/02_*/02_00*
 
     - name: Run test 02_01
       run: |
-        ./tests/00_*/02_01*
+        ./tests/02_*/02_01*
 
   removeLabel:
     if : ${{ !cancelled() && github.event.label.name == 'test' }}

--- a/tests/02_multiAction/02_00_basicParallel.sh
+++ b/tests/02_multiAction/02_00_basicParallel.sh
@@ -96,6 +96,15 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_dep_order.sh \
   $test0 "$test0_step0=[] $test0_step1=[] $test0_step2=[] $test0_step3=[]"
 result=$?
 
+# we know steps are submitted in appearing order from the test config so this will work
+# when using the test script that sleeps to enforce coherency
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_parallel.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 "$test0_step0=[$test0_step1,$test0_step2,$test0_step3] \
+          $test0_step1=[$test0_step2,$test0_step3] \
+          $test0_step2=[$test0_step3]"
+result=$?
+
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "arg0 arg1" true
 result=$?
 

--- a/tests/02_multiAction/02_00_basicParallel.sh
+++ b/tests/02_multiAction/02_00_basicParallel.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# https://stackoverflow.com/a/29835459
+CURRENT_SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+
+. $CURRENT_SOURCE_DIR/../scripts/helpers.sh
+. $CURRENT_SOURCE_DIR/../scripts/checkers.sh
+
+echo "Tests for $( basename $0 )"
+echo "Purpose:"
+echo "  Check that when a multi-step test runs, if no dependencies are set all steps will maximize usage of threadpool"
+
+# 
+redirect=$( mktemp $CURRENT_SOURCE_DIR/test_XXXX )
+suite=02_multiAction
+suite_relfile=$suite.json
+suite_reloffset=""
+suiteStdout=$redirect
+$CURRENT_SOURCE_DIR/../../.ci/runner.py $CURRENT_SOURCE_DIR/$suite.json -t basicParallel -tp 4 > $redirect 2>&1
+result=$?
+
+
+test0=basicParallel
+test0_step0=stepA
+test0_step1=stepB
+test0_step2=stepC
+test0_step3=stepD
+
+justify "<" "*" 100 "-->[SUITE RUNS OK] "
+reportTest                                                                      \
+  SUITE_SUCCESS                                                                 \
+  "Suite should report success when everything passes"                       \
+  0 0 $result
+result=$?
+
+
+justify "^" "*" 100 "->[CHECK LOGS EXIST]<-"
+$CURRENT_SOURCE_DIR/../scripts/helper_logs_generated.sh \
+  $result                                                 \
+  $CURRENT_SOURCE_DIR                                     \
+  $suite                                                  \
+  "$test0=[$test0_step0,$test0_step1,$test0_step2,$test0_step3]" \
+  "$suite_relfile"                                        \
+  "$suite_reloffset"                                      \
+  $suiteStdout
+result=$?
+
+justify "^" "*" 100 "->[CHECK PASSED TEST]<-"
+$CURRENT_SOURCE_DIR/../scripts/helper_masterlog_report.sh \
+  $result $CURRENT_SOURCE_DIR $suite                        \
+  $test0 true                                              \
+  "$test0_step0=true $test0_step1=true $test0_step2=true $test0_step3=true"
+result=$?
+
+
+$CURRENT_SOURCE_DIR/../scripts/helper_main_stdout.sh $result $CURRENT_SOURCE_DIR $suiteStdout 1
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_main_stdout_report.sh $result $suiteStdout $test0 true true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout.sh \
+  $result $CURRENT_SOURCE_DIR $suite $test0 \
+  "$test0_step0=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step1=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step2=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step3=./tests/scripts/echo_normal_sleep.sh"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh \
+  $result $CURRENT_SOURCE_DIR $suite $test0 \
+  "$test0_step0=../../ \
+   $test0_step1=../../ \
+   $test0_step2=../../ \
+   $test0_step3=../../"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 true "$test0_step0=true $test0_step1=true $test0_step2=true $test0_step3=true"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_dep_order.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 "$test0_step0=[] $test0_step1=[] $test0_step2=[] $test0_step3=[]"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "arg0 arg1" true
+result=$?
+
+# Cleanup run
+rm $redirect
+rm $CURRENT_SOURCE_DIR/*.log
+
+exit $result

--- a/tests/02_multiAction/02_01_complexParallel.sh
+++ b/tests/02_multiAction/02_01_complexParallel.sh
@@ -125,6 +125,26 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_dep_order.sh \
           $test0_step7=[$test0_step5,$test0_step6]"
 result=$?
 
+# we know steps are submitted in appearing order from the test config so this will work
+# when using the test script that sleeps to enforce coherency
+# Steps A-D are submitted sequentially and thus run parallel as removed from queue
+# Step F will trigger after B+C complete which MUST BE before D completes (again due to coherency)
+# Step E will trigger after A+D complete, but by that point F is running and no other steps can be queued
+#  so Step E is run more-or-less "serially" even though F may or may not be finishing
+# Step G will only trigger after E is complete, and once again runs serially - this time most likely
+# Step H requires G+F which converges all steps and thus IS run completely serially
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_parallel.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 "$test0_step0=[$test0_step1,$test0_step2,$test0_step3] \
+          $test0_step1=[$test0_step2,$test0_step3]              \
+          $test0_step2=[$test0_step3]                           \
+          $test0_step3=[$test0_step5]                           \
+          $test0_step4=[]                                       \
+          $test0_step5=[$test0_step4]                           \
+          $test0_step6=[]                                       \
+          $test0_step7=[]"
+result=$?
+
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "arg0 arg1" true
 result=$?
 

--- a/tests/02_multiAction/02_01_complexParallel.sh
+++ b/tests/02_multiAction/02_01_complexParallel.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# https://stackoverflow.com/a/29835459
+CURRENT_SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+
+. $CURRENT_SOURCE_DIR/../scripts/helpers.sh
+. $CURRENT_SOURCE_DIR/../scripts/checkers.sh
+
+echo "Tests for $( basename $0 )"
+echo "Purpose:"
+echo "  Check that when a multi-step test runs, when dependencies are set even if threads are available deps will be respected"
+
+# 
+redirect=$( mktemp $CURRENT_SOURCE_DIR/test_XXXX )
+suite=02_multiAction
+suite_relfile=$suite.json
+suite_reloffset=""
+suiteStdout=$redirect
+test0=complexParallel
+test0_step0=stepA
+test0_step1=stepB
+test0_step2=stepC
+test0_step3=stepD
+test0_step4=stepE
+test0_step5=stepF
+test0_step6=stepG
+test0_step7=stepH
+$CURRENT_SOURCE_DIR/../../.ci/runner.py $CURRENT_SOURCE_DIR/$suite.json -t $test0 -tp 4 > $redirect 2>&1
+result=$?
+
+
+
+
+justify "<" "*" 100 "-->[SUITE RUNS OK] "
+reportTest                                                                      \
+  SUITE_SUCCESS                                                                 \
+  "Suite should report success when everything passes"                       \
+  0 0 $result
+result=$?
+
+
+justify "^" "*" 100 "->[CHECK LOGS EXIST]<-"
+$CURRENT_SOURCE_DIR/../scripts/helper_logs_generated.sh \
+  $result                                                 \
+  $CURRENT_SOURCE_DIR                                     \
+  $suite                                                  \
+  "$test0=[$test0_step0,$test0_step1,$test0_step2,$test0_step3,$test0_step4,$test0_step5,$test0_step6,$test0_step7]" \
+  "$suite_relfile"                                        \
+  "$suite_reloffset"                                      \
+  $suiteStdout
+result=$?
+
+justify "^" "*" 100 "->[CHECK PASSED TEST]<-"
+$CURRENT_SOURCE_DIR/../scripts/helper_masterlog_report.sh \
+  $result $CURRENT_SOURCE_DIR $suite                        \
+  $test0 true                                              \
+  "$test0_step0=true $test0_step1=true $test0_step2=true $test0_step3=true $test0_step4=true $test0_step5=true $test0_step6=true $test0_step7=true"
+result=$?
+
+
+$CURRENT_SOURCE_DIR/../scripts/helper_main_stdout.sh $result $CURRENT_SOURCE_DIR $suiteStdout 1
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_main_stdout_report.sh $result $suiteStdout $test0 true true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout.sh \
+  $result $CURRENT_SOURCE_DIR $suite $test0 \
+  "$test0_step0=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step1=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step2=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step3=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step4=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step5=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step6=./tests/scripts/echo_normal_sleep.sh \
+   $test0_step7=./tests/scripts/echo_normal_sleep.sh"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh \
+  $result $CURRENT_SOURCE_DIR $suite $test0 \
+  "$test0_step0=../../ \
+   $test0_step1=../../ \
+   $test0_step2=../../ \
+   $test0_step3=../../ \
+   $test0_step4=../../ \
+   $test0_step5=../../ \
+   $test0_step6=../../ \
+   $test0_step7=../../"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step4 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step5 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step6 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step7 "argset_01=\['arg0','arg1'\]" "argset_01=$suite"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 true "$test0_step0=true $test0_step1=true $test0_step2=true $test0_step3=true $test0_step4=true $test0_step5=true $test0_step6=true $test0_step7=true"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_step_dep_order.sh \
+  $result $CURRENT_SOURCE_DIR $suite \
+  $test0 "$test0_step0=[] $test0_step1=[] $test0_step2=[] $test0_step3=[] \
+          $test0_step4=[$test0_step0,$test0_step3] \
+          $test0_step5=[$test0_step1,$test0_step2] \
+          $test0_step6=[$test0_step4]              \
+          $test0_step7=[$test0_step5,$test0_step6]"
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step4 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step5 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step6 "arg0 arg1" true
+result=$?
+
+$CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step7 "arg0 arg1" true
+result=$?
+
+# Cleanup run
+rm $redirect
+rm $CURRENT_SOURCE_DIR/*.log
+
+exit $result

--- a/tests/02_multiAction/02_multiAction.json
+++ b/tests/02_multiAction/02_multiAction.json
@@ -1,0 +1,81 @@
+{
+  "submit_options" :
+  {
+    "working_directory" : "../../",
+    "resources"  : "list your resources here based on HPC specific system",
+    "queue"      : "economy",
+    "timelimit"  : "01:00:00",
+    "wait"       : "True if set, use with caution",
+    "arguments"  : 
+    { 
+      "argset_01"            : [ "arg0", "arg1" ]
+    },
+    "submission"  : "LOCAL"
+  },
+  "basicParallel" :
+  {
+    "steps" :
+    {
+      "stepA" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepB" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepC" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepD" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      }
+    }
+  },
+  "complexParallel" :
+  {
+    "steps" :
+    {
+      "stepA" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepB" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepC" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepD" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh"
+      },
+      "stepE" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh",
+        "dependencies" : { "stepA" : "afterany", "stepD" : "afterany" }
+      },
+      "stepF" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh",
+        "dependencies" : { "stepB" : "afterany", "stepC" : "afterany" }
+      }
+      ,
+      "stepG" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh",
+        "dependencies" : { "stepE" : "afterany" }
+      }
+      ,
+      "stepH" :
+      {
+        "command"      : "./tests/scripts/echo_normal_sleep.sh",
+        "dependencies" : { "stepF" : "afterany", "stepG" : "afterany" }
+      }
+    }
+  }
+}

--- a/tests/scripts/checkers.sh
+++ b/tests/scripts/checkers.sh
@@ -41,6 +41,14 @@ getLineBetween()
   fi
 }
 
+getLine()
+{
+  func_filename="$1"
+  func_regex="$2"
+  grep -Esn "$func_regex" $func_filename
+  return $?
+}
+
 checkLastLine()
 {
   func_filename="$1"

--- a/tests/scripts/echo_normal_sleep.sh
+++ b/tests/scripts/echo_normal_sleep.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+dir=$1
+cd $dir
+
+shift
+echo $*
+sleep 1
+echo "TEST $(basename $0) PASS"

--- a/tests/scripts/helper_test_stdout_step_dep_order.sh
+++ b/tests/scripts/helper_test_stdout_step_dep_order.sh
@@ -40,6 +40,7 @@ for helper_step in $helper_steps; do
       helper_stepDepIdx=$(( $helper_stepDepIdx + 1 ))
     done
   else
+    justify "<" "*" 100 "-->[STEP [$helper_step] NO DEPENDENCY ORDER] "
     # This step has no dependencies, it should start whenever but before the test is done (obviously)
     checkTestBetween                                                                \
       TEST_STDOUT_STEP_NO_DEPENDENCIES                                              \

--- a/tests/scripts/helper_test_stdout_step_dep_order.sh
+++ b/tests/scripts/helper_test_stdout_step_dep_order.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+helper_result=$1
+helper_logdir=$2
+helper_suite=$3
+helper_testname=$4
+helper_mapping="$5"
+
+SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+. $SOURCE_DIR/helpers.sh
+. $SOURCE_DIR/checkers.sh
+
+helper_testStdout_loc=$( format $testStdout_fmt logdir=$helper_logdir suite=$helper_suite testname=$helper_testname )
+
+justify "<" "*" 100 "-->[TEST [$helper_testname] STDOUT STEP DEPENDENCY ORDER] "
+
+helper_steps=$( getKeys "$helper_mapping" )
+for helper_step in $helper_steps; do
+
+  helper_stepStartLine=$( getLine $helper_testStdout_loc                                                        \
+                          "\[step::$helper_step\][ ]*Preparing working directory" | awk -F ':' '{print $1}' )
+
+  helper_stepDependencies=$( splitValues $( getValuesAtKey "$helper_mapping" $helper_step ) )
+  if [ -n "$helper_stepDependencies" ]; then
+    justify "<" "*" 100 "-->[STEP [$helper_step] DEPENDENCY ORDER] "
+
+    helper_stepDepEndLine=9999999
+    helper_stepDepIdx=0
+    for helper_stepDep in $helper_stepDependencies; do
+      # Check that the stepDep finishes before our step even starts
+      helper_stepDepEndLine=$( getLine $helper_testStdout_loc                                                        \
+                                  "\[step::$helper_stepDep\][ ]*Finished submitting step $helper_stepDep" | awk -F ':' '{print $1}' )
+      test $helper_stepStartLine -gt $helper_stepDepEndLine
+      reportTest                                                           \
+        TEST_STDOUT_STEP_ORDER_DEP_$helper_stepDepIdx                      \
+        "Dependency [$helper_stepDep] finishes before [$helper_step] starts"   \
+        0 $helper_result $?
+      helper_result=$?
+
+      # Set new index
+      helper_stepDepIdx=$(( $helper_stepDepIdx + 1 ))
+    done
+  else
+    # This step has no dependencies, it should start whenever but before the test is done (obviously)
+    checkTestBetween                                                                \
+      TEST_STDOUT_STEP_NO_DEPENDENCIES                                              \
+      "Step [$helper_step] has no dependencies and need only finish by test end"    \
+      0 $helper_result                                                              \
+      $helper_testStdout_loc                                                        \
+      "\[step::$helper_step\][ ]*Finished submitting step $helper_step"             \
+      "\[test::$helper_testname\][ ]*Preparing working directory"                   \
+      "\[test::$helper_testname\][ ]*No remaining steps, test submission complete"
+    helper_result=$?
+  fi
+done
+
+exit $helper_result

--- a/tests/scripts/helper_test_stdout_step_parallel.sh
+++ b/tests/scripts/helper_test_stdout_step_parallel.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+helper_result=$1
+helper_logdir=$2
+helper_suite=$3
+helper_testname=$4
+helper_mapping="$5"
+
+SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+. $SOURCE_DIR/helpers.sh
+. $SOURCE_DIR/checkers.sh
+
+helper_testStdout_loc=$( format $testStdout_fmt logdir=$helper_logdir suite=$helper_suite testname=$helper_testname )
+
+justify "<" "*" 100 "-->[TEST [$helper_testname] STDOUT STEP PARALLEL PHASE] "
+
+helper_steps=$( getKeys "$helper_mapping" )
+for helper_step in $helper_steps; do
+
+  helper_stepEndLine=$( getLine $helper_testStdout_loc                                                        \
+                          "\[step::$helper_step\][ ]*Finished submitting step $helper_step" | awk -F ':' '{print $1}' )
+
+  helper_stepsParallel=$( splitValues $( getValuesAtKey "$helper_mapping" $helper_step ) )
+  if [ -n "$helper_stepsParallel" ]; then
+    justify "<" "*" 100 "-->[STEP [$helper_step] PARALLEL STEPS] "
+
+    helper_stepParStartLine=9999999
+    helper_stepParIdx=0
+    for helper_stepPar in $helper_stepsParallel; do
+      # Check that the stepPar starts before our step even finishes
+      helper_stepParStartLine=$( getLineBetween $helper_testStdout_loc                                                        \
+                                "\[step::$helper_stepPar\][ ]*Submitting step $helper_stepPar"   \
+                                "\[step::$helper_step\][ ]*Submitting step $helper_step"         \
+                                "\[step::$helper_step\][ ]*Finished submitting step $helper_step" | awk '{print $1}' )
+
+      test $helper_stepEndLine -gt $helper_stepParStartLine
+      reportTest                                                           \
+        TEST_STDOUT_STEP_PARALLEL_$helper_stepParIdx                      \
+        "Parallel step [$helper_stepPar] starts before [$helper_step] finishes"  \
+        0 $helper_result $?
+      helper_result=$?
+
+      # Set new index
+      helper_stepParIdx=$(( $helper_stepParIdx + 1 ))
+    done
+  else
+    justify "<" "*" 100 "-->[STEP [$helper_step] SERIAL STEP] "
+    # This step has no parallel steps, it should look like it runs serially aside from already running jobs printing
+    # We can do this check like this since the code ensures locking printing to the console whilst a job
+    # is preparing to submit and only relinquishes the lock between START/STOP phase
+    checkTestBetween                                                                \
+      TEST_STDOUT_STEP_NO_PARALLEL                                                  \
+      "Step [$helper_step] has no parallel steps and should not have any steps submit while running" \
+      1 $helper_result                                                              \
+      $helper_testStdout_loc                                                        \
+      "\[step::.*\][ ]*Submitting step"                                \
+      "\[step::$helper_step\].*START $helper_step"         \
+      "\[step::$helper_step\].*STOP $helper_step"
+    helper_result=$?
+  fi
+done
+
+exit $helper_result


### PR DESCRIPTION
Add the ability to launch steps whose dependencies have been satisfied (i.e. are [`runnable`](https://github.com/islas/hpc-workflows/blob/b7d538bab756b8975c57ae6eb36f67f7b7a3df6e/.ci/Step.py#L91C1-L91C1)) in parallel within a thread pool.

Optimized with focus on :
* Non-polling interrupts to wake main test thread to check for new runnable steps
* Serializing console printing to make sure test stdout comes in a cohesive manner
* Fault-tolerant to properly clean up and report errors when catastrophic step failure occurs 