### PR TITLE
Resource allocation multistep

### DIFF
--- a/.ci/SubmitOptions.py
+++ b/.ci/SubmitOptions.py
@@ -534,7 +534,8 @@ class SubmitOptions( ) :
                     raise Exception( msg )
                 else :
                   # Not sure how to add, leave as is
-                  print( "Unsure how to operate on resources {0} and {1} together, defaulting to {0}".format( finalResourceBreakdown[ group ][ res ], amount ) )
+                  pass
+                  # print( "Unsure how to operate on resources {0} and {1} together, defaulting to {0}".format( finalResourceBreakdown[ group ][ res ], amount ) )
             else :
               # Just add
               finalResourceBreakdown[ group ][ res ] = amount


### PR DESCRIPTION
#18 Added the ability to multithread steps, but only takes the aggregate of all runnable steps to be the max resources, without accounting for the size of the threadpool.

These changes walk through slightly similar logic to the tests' pool simulation, accounting for instantaneous max resources used based on provided timelimit of that action. For steps the additional complexity comes from dependency tracking whereas tests are independent.

Step max resource allocation is now based on instantaneous consumption of resources from the running of steps in the order prescribed by the test config and any dependencies when steps are run for the exact timelimit assigned.