### PR TITLE
Defer the selection of host-specific options

### DIFF
--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -62,6 +62,7 @@ class Step( SubmitAction ):
         self.dependencies_[ depStep ] = Step.DependencyType( depType )
 
     # Now set things manually
+    self.submitOptions_ = self.submitOptions_.selectHostSpecificSubmitOptions()
     self.submitOptions_.name_ = self.ancestry()
 
     valid, msg = self.submitOptions_.validate()

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -23,7 +23,7 @@ class SubmitAction( ) :
 
     self.parent_        = parent
     self.options_       = options
-    self.submitOptions_ = copy.deepcopy( defaultSubmitOptions ).selectHostSpecificSubmitOptions()
+    self.submitOptions_ = copy.deepcopy( defaultSubmitOptions )
 
     self.rootDir_          = rootDir
     self.printDir_         = False
@@ -56,7 +56,7 @@ class SubmitAction( ) :
   def parse( self ) :
     key = "submit_options"
     if key in self.options_ :
-      self.submitOptions_.update( SubmitOptions( self.options_[ key ], origin=self.name_ ).selectHostSpecificSubmitOptions(), print=self.log )
+      self.submitOptions_.update( SubmitOptions( self.options_[ key ], origin=self.ancestry() ), print=self.log )
 
     # Now call child parse
     self.parseSpecificOptions()

--- a/tests/00_submitOptions/00_03_overrideAtTest.sh
+++ b/tests/00_submitOptions/00_03_overrideAtTest.sh
@@ -57,7 +57,7 @@ result=$?
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh $result $CURRENT_SOURCE_DIR $suite $test0 "$test0_step0=../"
 result=$?
 
-$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg2','arg3'\]" "argset_01=$test0"
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg2','arg3'\]" "argset_01=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh $result $CURRENT_SOURCE_DIR $suite $test0 true "$test0_step0=true"

--- a/tests/00_submitOptions/00_04_overrideAtStep.sh
+++ b/tests/00_submitOptions/00_04_overrideAtStep.sh
@@ -57,7 +57,7 @@ result=$?
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh $result $CURRENT_SOURCE_DIR $suite $test0 "$test0_step0=."
 result=$?
 
-$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg4','arg5'\]" "argset_01=$test0_step0"
+$CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "argset_01=\['arg4','arg5'\]" "argset_01=$suite.$test0.$test0_step0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh $result $CURRENT_SOURCE_DIR $suite $test0 true "$test0_step0=true"

--- a/tests/00_submitOptions/00_06_argpackRegexOverrideAtTest.sh
+++ b/tests/00_submitOptions/00_06_argpackRegexOverrideAtTest.sh
@@ -58,7 +58,7 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh $result $CURREN
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 \
-  "argset_01=\['arg0','arg1'\] \.\*regex\.\*::argset_02=\['overrideAtTest'\]" "argset_01=$suite \.\*regex\.\*::argset_02=$test0"
+  "argset_01=\['arg0','arg1'\] \.\*regex\.\*::argset_02=\['overrideAtTest'\]" "argset_01=$suite \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh $result $CURRENT_SOURCE_DIR $suite $test0 true "$test0_step0=true"

--- a/tests/00_submitOptions/00_07_argpackRegexOverrideAtStep.sh
+++ b/tests/00_submitOptions/00_07_argpackRegexOverrideAtStep.sh
@@ -58,7 +58,7 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_working_dir.sh $result $CURREN
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 \
-  "argset_01=\['arg0','arg1'\] \.\*regex\.\*::argset_02=\['overrideAtStep'\]" "argset_01=$suite \.\*regex\.\*::argset_02=$test0_step0"
+  "argset_01=\['arg0','arg1'\] \.\*regex\.\*::argset_02=\['overrideAtStep'\]" "argset_01=$suite \.\*regex\.\*::argset_02=$suite.$test0.$test0_step0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_report.sh $result $CURRENT_SOURCE_DIR $suite $test0 true "$test0_step0=true"

--- a/tests/00_submitOptions/00_08_argpackRegexApplyAtSpecificAncestry.sh
+++ b/tests/00_submitOptions/00_08_argpackRegexApplyAtSpecificAncestry.sh
@@ -79,9 +79,9 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "\.\*setA\.\*::argRegexA=\['setA'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setA\.\*::argRegexA=$test0                \
+  "\.\*setA\.\*::argRegexA=$suite.$test0         \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "setA arg0 arg1" true
@@ -92,9 +92,9 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "\.\*setB\.\*::argRegexB=\['setB'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setB\.\*::argRegexB=$test0                \
+  "\.\*setB\.\*::argRegexB=$suite.$test0         \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 "setB arg0 arg1" true
@@ -106,10 +106,10 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setB\.\*::argRegexB=\['setB'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setA\.\*::argRegexA=$test0                \
-   \.\*setB\.\*::argRegexB=$test0                \
+  "\.\*setA\.\*::argRegexA=$suite.$test0         \
+   \.\*setB\.\*::argRegexB=$suite.$test0         \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "setA setB arg0 arg1" true
@@ -120,14 +120,14 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
   "argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 \
   "\.\*setA\.\*::argRegexA=\['setA'\]             \
    \.\*setB\.\*::argRegexB=\['setB'\]"            \
-  "\.\*setA\.\*::argRegexA=$test0                \
-   \.\*setB\.\*::argRegexB=$test0" false
+  "\.\*setA\.\*::argRegexA=$suite.$test0          \
+   \.\*setB\.\*::argRegexB=$suite.$test0" false
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "arg0 arg1" true

--- a/tests/00_submitOptions/00_09_argpackRegexApplyAtSpecificAncestrySame.sh
+++ b/tests/00_submitOptions/00_09_argpackRegexApplyAtSpecificAncestrySame.sh
@@ -80,17 +80,17 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setA\.\*::argRegex=\['setA'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setB\.\*::argRegex=$test0                \
-   \.\*setA\.\*::argRegex=$test0                \
+  "\.\*setB\.\*::argRegex=$suite.$test0          \
+   \.\*setA\.\*::argRegex=$suite.$test0          \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 \
   "\.\*setD\.\*::argRegex=\['setD'\]             \
    \.\*setC\.\*::argRegex=\['setC'\]" \
-  "\.\*setD\.\*::argRegex=$test0                \
-   \.\*setC\.\*::argRegex=$test0" false
+  "\.\*setD\.\*::argRegex=$suite.$test0          \
+   \.\*setC\.\*::argRegex=$suite.$test0" false
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "setB setA arg0 arg1" true
@@ -102,17 +102,17 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setC\.\*::argRegex=\['setC'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setD\.\*::argRegex=$test0                \
-   \.\*setC\.\*::argRegex=$test0                \
+  "\.\*setD\.\*::argRegex=$suite.$test0          \
+   \.\*setC\.\*::argRegex=$suite.$test0          \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 \
   "\.\*setB\.\*::argRegex=\['setB'\]             \
    \.\*setA\.\*::argRegex=\['setA'\]" \
-  "\.\*setB\.\*::argRegex=$test0                \
-   \.\*setA\.\*::argRegex=$test0" false
+  "\.\*setB\.\*::argRegex=$suite.$test0          \
+   \.\*setA\.\*::argRegex=$suite.$test0" false
 result=$?
 
 
@@ -127,12 +127,12 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setC\.\*::argRegex=\['setC'\]             \
    argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
-  "\.\*setB\.\*::argRegex=$test0                \
-   \.\*setA\.\*::argRegex=$test0                \
-   \.\*setD\.\*::argRegex=$test0                \
-   \.\*setC\.\*::argRegex=$test0                \
+  "\.\*setB\.\*::argRegex=$suite.$test0          \
+   \.\*setA\.\*::argRegex=$suite.$test0          \
+   \.\*setD\.\*::argRegex=$suite.$test0          \
+   \.\*setC\.\*::argRegex=$suite.$test0          \
    argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "setB setA setD setC arg0 arg1" true
@@ -143,7 +143,7 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
   "argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 \
@@ -151,10 +151,10 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setA\.\*::argRegex=\['setA'\]             \
    \.\*setD\.\*::argRegex=\['setD'\]             \
    \.\*setC\.\*::argRegex=\['setC'\]" \
-  "\.\*setB\.\*::argRegex=$test0                \
-   \.\*setA\.\*::argRegex=$test0                \
-   \.\*setD\.\*::argRegex=$test0                \
-   \.\*setC\.\*::argRegex=$test0" false
+  "\.\*setB\.\*::argRegex=$suite.$test0          \
+   \.\*setA\.\*::argRegex=$suite.$test0          \
+   \.\*setD\.\*::argRegex=$suite.$test0          \
+   \.\*setC\.\*::argRegex=$suite.$test0" false
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "arg0 arg1" true

--- a/tests/00_submitOptions/00_10_argpackRegexApplyAtSpecificAncestryAlpha.sh
+++ b/tests/00_submitOptions/00_10_argpackRegexApplyAtSpecificAncestryAlpha.sh
@@ -106,14 +106,14 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "\.\*setD\.\*::alwaysFirst=$suite.$test0            \
    argset_01=$suite                                \
    \.\*regex\.\*::argset_02=$suite.$test0
-   \.\*setC\.\*::needsToBeBetween_b_and_s=$test0"
+   \.\*setC\.\*::needsToBeBetween_b_and_s=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 \
   "\.\*setB\.\*::beSecondSet=\['setB'\]             \
    \.\*setA\.\*::shouldBeLast=\['setA'\]" \
   "\.\*setB\.\*::beSecondSet=$suite.$test0          \
-   \.\*setA\.\*::shouldBeLast=$test0" false
+   \.\*setA\.\*::shouldBeLast=$suite.$test0" false
 result=$?
 
 

--- a/tests/00_submitOptions/00_10_argpackRegexApplyAtSpecificAncestryAlpha.sh
+++ b/tests/00_submitOptions/00_10_argpackRegexApplyAtSpecificAncestryAlpha.sh
@@ -82,16 +82,16 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setB\.\*::beSecondSet=\['setB'\]             \
    \.\*setA\.\*::shouldBeLast=\['setA'\]" \
   "argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0               \
-   \.\*setB\.\*::beSecondSet=$test0                 \
-   \.\*setA\.\*::shouldBeLast=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0        \
+   \.\*setB\.\*::beSecondSet=$suite.$test0       \
+   \.\*setA\.\*::shouldBeLast=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 \
   "\.\*setD\.\*::alwaysFirst=\['setD'\]             \
    \.\*setC\.\*::needsToBeBetween_b_and_s=\['setC'\]" \
-  "\.\*setD\.\*::alwaysFirst=$test0                \
-   \.\*setC\.\*::needsToBeBetween_b_and_s=$test0" false
+  "\.\*setD\.\*::alwaysFirst=$suite.$test0                \
+   \.\*setC\.\*::needsToBeBetween_b_and_s=$suite.$test0" false
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step0 "arg0 arg1 setB setA" true
@@ -103,16 +103,16 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   argset_01=\['arg0','arg1'\]                         \
    \.\*regex\.\*::argset_02=\[\]                      \
    \.\*setC\.\*::needsToBeBetween_b_and_s=\['setC'\]" \
-  "\.\*setD\.\*::alwaysFirst=$test0                \
+  "\.\*setD\.\*::alwaysFirst=$suite.$test0            \
    argset_01=$suite                                \
-   \.\*regex\.\*::argset_02=$test0
+   \.\*regex\.\*::argset_02=$suite.$test0
    \.\*setC\.\*::needsToBeBetween_b_and_s=$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step1 \
   "\.\*setB\.\*::beSecondSet=\['setB'\]             \
    \.\*setA\.\*::shouldBeLast=\['setA'\]" \
-  "\.\*setB\.\*::beSecondSet=$test0                \
+  "\.\*setB\.\*::beSecondSet=$suite.$test0          \
    \.\*setA\.\*::shouldBeLast=$test0" false
 result=$?
 
@@ -128,12 +128,12 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setB\.\*::beSecondSet=\['setB'\]                 \
    \.\*setC\.\*::needsToBeBetween_b_and_s=\['setC'\] \
    \.\*setA\.\*::shouldBeLast=\['setA'\]"            \
-  "\.\*setD\.\*::alwaysFirst=$test0                  \
+  "\.\*setD\.\*::alwaysFirst=$suite.$test0           \
    argset_01=$suite                                  \
-   \.\*regex\.\*::argset_02=$test0                   \
-   \.\*setB\.\*::beSecondSet=$test0                     \
-   \.\*setC\.\*::needsToBeBetween_b_and_s=$test0     \
-   \.\*setA\.\*::shouldBeLast=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0            \
+   \.\*setB\.\*::beSecondSet=$suite.$test0                  \
+   \.\*setC\.\*::needsToBeBetween_b_and_s=$suite.$test0     \
+   \.\*setA\.\*::shouldBeLast=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step2 "setD arg0 arg1 setB setC setA" true
@@ -144,7 +144,7 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
   "argset_01=\['arg0','arg1'\]                    \
    \.\*regex\.\*::argset_02=\[\]" \
   "argset_01=$suite                              \
-   \.\*regex\.\*::argset_02=$test0"
+   \.\*regex\.\*::argset_02=$suite.$test0"
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 \
@@ -152,10 +152,10 @@ $CURRENT_SOURCE_DIR/../scripts/helper_test_stdout_argpacks.sh $result $CURRENT_S
    \.\*setA\.\*::shouldBeLast=\['setA'\]             \
    \.\*setD\.\*::alwaysFirst=\['setD'\]             \
    \.\*setC\.\*::needsToBeBetween_b_and_s=\['setC'\]" \
-  "\.\*setB\.\*::beSecondSet=$test0                \
-   \.\*setA\.\*::shouldBeLast=$test0                \
-   \.\*setD\.\*::alwaysFirst=$test0                \
-   \.\*setC\.\*::needsToBeBetween_b_and_s=$test0" false
+  "\.\*setB\.\*::beSecondSet=$suite.$test0            \
+   \.\*setA\.\*::shouldBeLast=$suite.$test0           \
+   \.\*setD\.\*::alwaysFirst=$suite.$test0            \
+   \.\*setC\.\*::needsToBeBetween_b_and_s=$suite.$test0" false
 result=$?
 
 $CURRENT_SOURCE_DIR/../scripts/helper_step_stdout.sh $result $CURRENT_SOURCE_DIR $suite $test0 $test0_step3 "arg0 arg1" true


### PR DESCRIPTION
Sometimes the FQDN query is slow, thus checking every time we create, update or otherwise look at the SubmitAction seems meaningless when the info can be fully gathered later at the step phase.

Additionally, the origin tracking of argpacks now includes the full ancestry.