### PR TITLE
Update markdown generation to do correct whitespacing

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -5,6 +5,7 @@ on:
     types: [ opened, synchronize ]
     paths:
       - tutorials/**
+      - .github/workflows/gendocs.yml
 
 jobs:
   markdowndocs:

--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -29,7 +29,7 @@ jobs:
           # --execute is hot garbage compared to manual execution, they produce different file outputs
           # which leads to weird newlines as code output stdout streams separate EVERY line as individual outputs
           jupyter nbconvert --execute      --inplace $notebook
-          ./tutorials/sanitize.py                    $notebook
+          ./tutorials/sanitizer.py                   $notebook
           jupyter nbconvert --to=markdown            $notebook
           jupyter nbconvert --clear-output --inplace $notebook
         done

--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -26,7 +26,10 @@ jobs:
     - name: Run all tutorials
       run: |
         for notebook in $( ls ./tutorials/*.ipynb ); do
+          # --execute is hot garbage compared to manual execution, they produce different file outputs
+          # which leads to weird newlines as code output stdout streams separate EVERY line as individual outputs
           jupyter nbconvert --execute      --inplace $notebook
+          ./tutorials/sanitize.py                    $notebook
           jupyter nbconvert --to=markdown            $notebook
           jupyter nbconvert --clear-output --inplace $notebook
         done

--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Run all tutorials
       run: |
         for notebook in $( ls ./tutorials/*.ipynb ); do
-          jupyter nbconvert --to=markdown  --execute $notebook
+          jupyter nbconvert --execute      --inplace $notebook
+          jupyter nbconvert --to=markdown            $notebook
+          jupyter nbconvert --clear-output --inplace $notebook
         done
     - name: Update documentation
       env:

--- a/tutorials/AdvancedRunOption_join_hpc.md
+++ b/tutorials/AdvancedRunOption_join_hpc.md
@@ -1705,7 +1705,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 \
     [step::submit]        Gathering HPC argument packs...
 
 
-    [step::submit]          From [cli, join] adding HPC argument pack 'select' :
+    [step::submit]          From [join, cli] adding HPC argument pack 'select' :
 
 
     [step::submit]            Adding option '-l '

--- a/tutorials/AdvancedRunOption_join_hpc.md
+++ b/tutorials/AdvancedRunOption_join_hpc.md
@@ -26,53 +26,21 @@ $1/../.ci/runner.py $1/../our-config.json -h | \
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     usage: runner.py [-h] [-t TESTS [TESTS ...]] [-s {PBS,SLURM,LOCAL}]
-
-
                      [-a ACCOUNT] [-d DIROFFSET] [-j [JOINHPC]]
-
-
                      [-alt [ALTDIRS ...]] [-l LABELLENGTH] [-g GLOBALPREFIX]
-
-
                      [-dry] [-nf] [-nw] [-np] [-k KEY] [-p POOL] [-tp THREADPOOL]
-
-
                      [-r REDIRECT] [-i] [-ff FORCEFQDN] [-fs]
-
-
                      testsConfig
-
-
     
-
-
     positional arguments:
-
-
       testsConfig           JSON file defining set of tests
-
-
     
-
-
     options:
-
-
     ...
-
-
       -j [JOINHPC], --joinHPC [JOINHPC]
-
-
                             Join test submissions into single collective HPC submission, use additional argument to override submission arguments using config syntax, e.g -j '{"select":{"-l ":{"select":1}}}'
-
-
     ...
 
 
@@ -158,227 +126,79 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "main",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "select" : 
-
-
           { 
-
-
             "-l " : 
-
-
             {
-
-
               "select" : 1,
-
-
               "mem"    : "32gb"
-
-
             }
-
-
           },
-
-
           "priority" :
-
-
           {
-
-
             "-l " :
-
-
             {
-
-
               "job_priority" : "economy"
-
-
             }
-
-
           }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering HPC argument packs...
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step0]         Adding option '-l '
-
-
     [step::our-step0]           From our-config adding resource 'select' : 1
-
-
     [step::our-step0]           From our-config adding resource 'mem'    : 32gb
-
-
     [step::our-step0]       Final argpack output for select : '-l select=1:mem=32gb'
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'priority' :
-
-
     [step::our-step0]         Adding option '-l '
-
-
     [step::our-step0]           From our-config adding resource 'job_priority' : economy
-
-
     [step::our-step0]       Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -437,479 +257,163 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -fs -
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "main",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "select" : 
-
-
           { 
-
-
             "-l " : 
-
-
             {
-
-
               "select" : 1,
-
-
               "mem"    : "32gb"
-
-
             }
-
-
           },
-
-
           "priority" :
-
-
           {
-
-
             "-l " :
-
-
             {
-
-
               "job_priority" : "economy"
-
-
             }
-
-
           }
-
-
         }
-
-
       },
-
-
       "our-test0" :
-
-
       {
-
-
         "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       },
-
-
       "our-test1" :
-
-
       {
-
-
         "steps" : { "our-step1" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       },
-
-
       "our-test2" :
-
-
       {
-
-
         "steps" : { "our-step2" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test0]   Preparing working directory
-
-
     [test::our-test0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test0]   Checking if results wait is required...
-
-
     [test::our-test0]     Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering HPC argument packs...
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step0]         Adding option '-l '
-
-
     [step::our-step0]           From our-config adding resource 'select' : 1
-
-
     [step::our-step0]           From our-config adding resource 'mem'    : 32gb
-
-
     [step::our-step0]       Final argpack output for select : '-l select=1:mem=32gb'
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'priority' :
-
-
     [step::our-step0]         Adding option '-l '
-
-
     [step::our-step0]           From our-config adding resource 'job_priority' : economy
-
-
     [step::our-step0]       Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test0.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test0.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test0]   Checking remaining steps...
-
-
     [test::our-test0]   No remaining steps, test submission complete
-
-
     [test::our-test0]   Doing dry-run, assumed complete
-
-
     [test::our-test0]   Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test0]   Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test0]     /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test0.log
-
-
     [test::our-test0]   [SUCCESS] : Test our-test0 completed successfully
-
-
     [test::our-test1]   Preparing working directory
-
-
     [test::our-test1]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test1]   Checking if results wait is required...
-
-
     [test::our-test1]     Final results will wait for all jobs complete
-
-
     [step::our-step1]   Preparing working directory
-
-
     [step::our-step1]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]   Submitting step our-step1...
-
-
     [step::our-step1]     Gathering HPC argument packs...
-
-
     [step::our-step1]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step1]         Adding option '-l '
-
-
     [step::our-step1]           From our-config adding resource 'select' : 1
-
-
     [step::our-step1]           From our-config adding resource 'mem'    : 32gb
-
-
     [step::our-step1]       Final argpack output for select : '-l select=1:mem=32gb'
-
-
     [step::our-step1]       From [our-config] adding HPC argument pack 'priority' :
-
-
     [step::our-step1]         Adding option '-l '
-
-
     [step::our-step1]           From our-config adding resource 'job_priority' : economy
-
-
     [step::our-step1]       Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::our-step1]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step1]     Running command:
-
-
     [step::our-step1]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test1.our-step1 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test1.our-step1.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]     ***************START our-step1***************
-
-
     
-
-
     [step::our-step1]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step1]     ***************STOP our-step1 ***************
-
-
     [step::our-step1]     Finding job ID in "12345"
-
-
     [step::our-step1]   Finished submitting step our-step1
-
-
     
-
-
     [test::our-test1]   Checking remaining steps...
-
-
     [test::our-test1]   No remaining steps, test submission complete
-
-
     [test::our-test1]   Doing dry-run, assumed complete
-
-
     [test::our-test1]   Outputting results...
-
-
     [step::our-step1]   Results for our-step1
-
-
     [step::our-step1]     Doing dry-run, assumed success
-
-
     [test::our-test1]   Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test1]     /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test1.log
-
-
     [test::our-test1]   [SUCCESS] : Test our-test1 completed successfully
-
-
     [test::our-test2]   Preparing working directory
-
-
     [test::our-test2]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test2]   Checking if results wait is required...
-
-
     [test::our-test2]     Final results will wait for all jobs complete
-
-
     [step::our-step2]   Preparing working directory
-
-
     [step::our-step2]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step2]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step2]   Submitting step our-step2...
-
-
     [step::our-step2]     Gathering HPC argument packs...
-
-
     [step::our-step2]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step2]         Adding option '-l '
-
-
     [step::our-step2]           From our-config adding resource 'select' : 1
-
-
     [step::our-step2]           From our-config adding resource 'mem'    : 32gb
-
-
     [step::our-step2]       Final argpack output for select : '-l select=1:mem=32gb'
-
-
     [step::our-step2]       From [our-config] adding HPC argument pack 'priority' :
-
-
     [step::our-step2]         Adding option '-l '
-
-
     [step::our-step2]           From our-config adding resource 'job_priority' : economy
-
-
     [step::our-step2]       Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::our-step2]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step2]     Running command:
-
-
     [step::our-step2]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test2.our-step2 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test2.our-step2.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step2]     ***************START our-step2***************
-
-
     
-
-
     [step::our-step2]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step2]     ***************STOP our-step2 ***************
-
-
     [step::our-step2]     Finding job ID in "12345"
-
-
     [step::our-step2]   Finished submitting step our-step2
-
-
     
-
-
     [test::our-test2]   Checking remaining steps...
-
-
     [test::our-test2]   No remaining steps, test submission complete
-
-
     [test::our-test2]   Doing dry-run, assumed complete
-
-
     [test::our-test2]   Outputting results...
-
-
     [step::our-step2]   Results for our-step2
-
-
     [step::our-step2]     Doing dry-run, assumed success
-
-
     [test::our-test2]   Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test2]     /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test2.log
-
-
     [test::our-test2]   [SUCCESS] : Test our-test2 completed successfully
 
 
@@ -923,263 +427,91 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Computing maximum HPC resources of tests...
-
-
     [file::our-config]  Accumulate maximum HPC resources per test...
-
-
     [test::our-test0]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test0]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test0]         Simulating threadpool for 0:01:00
-
-
     [test::our-test0]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test0]           [PHASE 0] Resources for [ our-step0 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test0]           1 jobs completed during this runtime
-
-
     [test::our-test0]       All jobs simulated, stopping
-
-
     [test::our-test0]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test1]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test1]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test1]         Simulating threadpool for 0:01:00
-
-
     [test::our-test1]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test1]           [PHASE 0] Resources for [ our-step1 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test1]           1 jobs completed during this runtime
-
-
     [test::our-test1]       All jobs simulated, stopping
-
-
     [test::our-test1]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test2]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test2]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test2]         Simulating threadpool for 0:01:00
-
-
     [test::our-test2]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test2]           [PHASE 0] Resources for [ our-step2 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test2]           1 jobs completed during this runtime
-
-
     [test::our-test2]       All jobs simulated, stopping
-
-
     [test::our-test2]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [file::our-config]  Calculating expected runtime of tests across 4 workers [pool size]
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 0] Resources for [  our-test0, our-test1, our-test2 ] : '-l select=3:mem=96gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      3 jobs completed during this runtime
-
-
     [file::our-config]  Maximum calculated resources for running all tests is '-l select=3:mem=96gb -l job_priority=economy'
-
-
     [file::our-config]  Maximum calculated timelimit for running all tests is '00:01:00'
-
-
     [file::our-config]  Using current file as launch executable : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [file::our-config]  Setting keyphrase for passing to internally defined one
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Preparing working directory
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking if results wait is required...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Final results will wait for all jobs complete
-
-
     [step::submit]      Preparing working directory
-
-
     [step::submit]        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]        Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]      Submitting step submit...
-
-
     [step::submit]        Gathering HPC argument packs...
-
-
     [step::submit]          From [join] adding HPC argument pack 'select' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'select' : 3
-
-
     [step::submit]              From join adding resource 'mem'    : 96gb
-
-
     [step::submit]          Final argpack output for select : '-l select=3:mem=96gb'
-
-
     [step::submit]          From [join] adding HPC argument pack 'priority' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'job_priority' : economy
-
-
     [step::submit]          Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::submit]        Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [step::submit]        Running command:
-
-
     [step::submit]          qsub -l select=3:mem=96gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 12 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal
-
-
     [step::submit]        *************** START submit  ***************
-
-
     
-
-
     [step::submit]        Doing dry-run, no ouptut
-
-
     
-
-
     [step::submit]        ***************  STOP submit  ***************
-
-
     [step::submit]        Finding job ID in "12345"
-
-
     [step::submit]      Finished submitting step submit
-
-
     
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking remaining steps...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] No remaining steps, test submission complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Doing dry-run, assumed complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Outputting results...
-
-
     [step::submit]      Results for submit
-
-
     [step::submit]        Doing dry-run, assumed success
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Writing relevant logfiles to view in master log file : 
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.log
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] [SUCCESS] : Test joinHPC_our-test0_our-test1_our-test2 completed successfully
-
-
     [file::our-config]  Joined HPC tests complete, above success only means tests managed to complete, please see logs for per-test success
-
-
     [file::our-config]  Post-processing all test results...
-
-
     [file::our-config]  Doing dry-run, assumed success
 
 
@@ -1204,281 +536,97 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Computing maximum HPC resources of tests...
-
-
     [file::our-config]  Accumulate maximum HPC resources per test...
-
-
     [test::our-test0]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test0]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test0]         Simulating threadpool for 0:01:00
-
-
     [test::our-test0]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test0]           [PHASE 0] Resources for [ our-step0 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test0]           1 jobs completed during this runtime
-
-
     [test::our-test0]       All jobs simulated, stopping
-
-
     [test::our-test0]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test1]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test1]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test1]         Simulating threadpool for 0:01:00
-
-
     [test::our-test1]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test1]           [PHASE 0] Resources for [ our-step1 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test1]           1 jobs completed during this runtime
-
-
     [test::our-test1]       All jobs simulated, stopping
-
-
     [test::our-test1]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test2]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test2]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test2]         Simulating threadpool for 0:01:00
-
-
     [test::our-test2]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test2]           [PHASE 0] Resources for [ our-step2 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test2]           1 jobs completed during this runtime
-
-
     [test::our-test2]       All jobs simulated, stopping
-
-
     [test::our-test2]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [file::our-config]  Calculating expected runtime of tests across 1 workers [pool size]
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]      [PHASE 0] Resources for [ our-test0 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      1 jobs completed during this runtime
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into None
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into None
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 1] Resources for [ our-test1 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      1 jobs completed during this runtime
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into None
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into None
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 2] Resources for [ our-test2 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      1 jobs completed during this runtime
-
-
     [file::our-config]  Maximum calculated resources for running all tests is '-l select=1:mem=32gb -l job_priority=economy'
-
-
     [file::our-config]  Maximum calculated timelimit for running all tests is '00:03:00'
-
-
     [file::our-config]  Using current file as launch executable : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [file::our-config]  Setting keyphrase for passing to internally defined one
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Preparing working directory
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking if results wait is required...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Final results will wait for all jobs complete
-
-
     [step::submit]      Preparing working directory
-
-
     [step::submit]        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]        Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]      Submitting step submit...
-
-
     [step::submit]        Gathering HPC argument packs...
-
-
     [step::submit]          From [join] adding HPC argument pack 'select' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'select' : 1
-
-
     [step::submit]              From join adding resource 'mem'    : 32gb
-
-
     [step::submit]          Final argpack output for select : '-l select=1:mem=32gb'
-
-
     [step::submit]          From [join] adding HPC argument pack 'priority' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'job_priority' : economy
-
-
     [step::submit]          Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::submit]        Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [step::submit]        Running command:
-
-
     [step::submit]          qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:03:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 12 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 1 --threadpool 1 --inlineLocal
-
-
     [step::submit]        *************** START submit  ***************
-
-
     
-
-
     [step::submit]        Doing dry-run, no ouptut
-
-
     
-
-
     [step::submit]        ***************  STOP submit  ***************
-
-
     [step::submit]        Finding job ID in "12345"
-
-
     [step::submit]      Finished submitting step submit
-
-
     
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking remaining steps...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] No remaining steps, test submission complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Doing dry-run, assumed complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Outputting results...
-
-
     [step::submit]      Results for submit
-
-
     [step::submit]        Doing dry-run, assumed success
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Writing relevant logfiles to view in master log file : 
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.log
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] [SUCCESS] : Test joinHPC_our-test0_our-test1_our-test2 completed successfully
-
-
     [file::our-config]  Joined HPC tests complete, above success only means tests managed to complete, please see logs for per-test success
-
-
     [file::our-config]  Post-processing all test results...
-
-
     [file::our-config]  Doing dry-run, assumed success
 
 
@@ -1535,269 +683,93 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 \
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Computing maximum HPC resources of tests...
-
-
     [file::our-config]  Accumulate maximum HPC resources per test...
-
-
     [test::our-test0]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test0]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test0]         Simulating threadpool for 0:01:00
-
-
     [test::our-test0]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test0]           [PHASE 0] Resources for [ our-step0 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test0]           1 jobs completed during this runtime
-
-
     [test::our-test0]       All jobs simulated, stopping
-
-
     [test::our-test0]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test1]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test1]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test1]         Simulating threadpool for 0:01:00
-
-
     [test::our-test1]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test1]           [PHASE 0] Resources for [ our-step1 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test1]           1 jobs completed during this runtime
-
-
     [test::our-test1]       All jobs simulated, stopping
-
-
     [test::our-test1]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::our-test2]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::our-test2]       Calculating expected runtime of steps across 1 thread workers [threadpool size]
-
-
     [test::our-test2]         Simulating threadpool for 0:01:00
-
-
     [test::our-test2]           Calculate max instantaneous resources for this phase
-
-
     [test::our-test2]           [PHASE 0] Resources for [ our-step2 ] : '-l select=1:mem=32gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::our-test2]           1 jobs completed during this runtime
-
-
     [test::our-test2]       All jobs simulated, stopping
-
-
     [test::our-test2]     Maximum HPC resources required will be '-l select=1:mem=32gb -l job_priority=economy' with timelimit '00:01:00'
-
-
     [file::our-config]  Calculating expected runtime of tests across 4 workers [pool size]
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 0] Resources for [  our-test0, our-test1, our-test2 ] : '-l select=3:mem=96gb -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      3 jobs completed during this runtime
-
-
     [file::our-config]  Maximum calculated resources for running all tests is '-l select=3:mem=96gb -l job_priority=economy'
-
-
     [file::our-config]  Maximum calculated timelimit for running all tests is '00:01:00'
-
-
     [file::our-config]  Requested override of resources with '{"select":{"-l ":{"select":1}},"priority":{"-l ":{"job_priority":"premium"}}}'
-
-
     [file::our-config]    New maximum resources for running all tests is '-l select=1:mem=96gb -l job_priority=premium'
-
-
     [file::our-config]  Using current file as launch executable : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [file::our-config]  Setting keyphrase for passing to internally defined one
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Preparing working directory
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking if results wait is required...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   Final results will wait for all jobs complete
-
-
     [step::submit]      Preparing working directory
-
-
     [step::submit]        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]        Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]      Submitting step submit...
-
-
     [step::submit]        Gathering HPC argument packs...
-
-
     [step::submit]          From [join, cli] adding HPC argument pack 'select' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From cli  adding resource 'select' : 1
-
-
     [step::submit]              From join adding resource 'mem'    : 96gb
-
-
     [step::submit]          Final argpack output for select : '-l select=1:mem=96gb'
-
-
     [step::submit]          From [cli] adding HPC argument pack 'priority' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From cli adding resource 'job_priority' : premium
-
-
     [step::submit]          Final argpack output for priority : '-l job_priority=premium'
-
-
     [step::submit]        Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [step::submit]        Running command:
-
-
     [step::submit]          qsub -l select=1:mem=96gb -l job_priority=premium -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 12 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal
-
-
     [step::submit]        *************** START submit  ***************
-
-
     
-
-
     [step::submit]        Doing dry-run, no ouptut
-
-
     
-
-
     [step::submit]        ***************  STOP submit  ***************
-
-
     [step::submit]        Finding job ID in "12345"
-
-
     [step::submit]      Finished submitting step submit
-
-
     
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Checking remaining steps...
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] No remaining steps, test submission complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Doing dry-run, assumed complete
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Outputting results...
-
-
     [step::submit]      Results for submit
-
-
     [step::submit]        Doing dry-run, assumed success
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] Writing relevant logfiles to view in master log file : 
-
-
     [test::joinHPC_our-test0_our-test1_our-test2]   /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.log
-
-
     [test::joinHPC_our-test0_our-test1_our-test2] [SUCCESS] : Test joinHPC_our-test0_our-test1_our-test2 completed successfully
-
-
     [file::our-config]  Joined HPC tests complete, above success only means tests managed to complete, please see logs for per-test success
-
-
     [file::our-config]  Post-processing all test results...
-
-
     [file::our-config]  Doing dry-run, assumed success
 
 
@@ -1921,311 +893,107 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "main",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           ".*quartnode.*::select" : 
-
-
           { 
-
-
             "-l " : 
-
-
             {
-
-
               "select" : 1,
-
-
               "mem"    : "32gb",
-
-
               "ncpus"  : 32,
-
-
               ".*mpi.*::mpiprocs" : 32
-
-
             }
-
-
           },
-
-
           ".*fullnode.*::select" :
-
-
           { 
-
-
             "-l " : 
-
-
             {
-
-
               "select" : 1,
-
-
               "mem"    : "128gb",
-
-
               "ncpus"  : 128,
-
-
               ".*mpi.*::mpiprocs" : 128
-
-
             }
-
-
           },
-
-
           "priority" :
-
-
           {
-
-
             "-l " :
-
-
             {
-
-
               "job_priority" : "economy"
-
-
             }
-
-
           }
-
-
         }
-
-
       },
-
-
       "quartnode-simple" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "hpc_arguments" : { ".*quartnode.*::select" : { "-l " : { "mem" : "16gb" } } }
-
-
         },
-
-
         "steps" : 
-
-
         {
-
-
           "our-step0" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           },
-
-
           "our-step0-mpi" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           }
-
-
         }
-
-
       },
-
-
       "quartnode" :
-
-
       {
-
-
         "steps" : 
-
-
         {
-
-
           "our-step0" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           },
-
-
           "our-step0-mpi" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           }
-
-
         }
-
-
       },
-
-
       "fullnode-simple" :
-
-
       {
-
-
         "steps" : 
-
-
         {
-
-
           "our-step0" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           },
-
-
           "our-step0-mpi" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           }
-
-
         }
-
-
       },
-
-
       "fullnode-double" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "hpc_arguments" : { ".*fullnode.*::select" : { "-l " : { "select" : 2 } } }
-
-
         },
-
-
         "steps" : 
-
-
         {
-
-
           "our-step0" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           },
-
-
           "our-step0-mpi" :
-
-
           {
-
-
             "command" : "./tests/scripts/echo_normal.sh"
-
-
           }
-
-
         }
-
-
       }
-
-
     }
 
 
@@ -2240,335 +1008,115 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Computing maximum HPC resources of tests...
-
-
     [file::our-config]  Accumulate maximum HPC resources per test...
-
-
     [test::quartnode-simple]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::quartnode-simple]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::quartnode-simple]       Simulating threadpool for 0:01:00
-
-
     [test::quartnode-simple]         Calculate max instantaneous resources for this phase
-
-
     [test::quartnode-simple]             Joining argpack '.*quartnode.*::select' from [our-config.quartnode-simple, our-config] into joinall
-
-
     [test::quartnode-simple]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::quartnode-simple]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::quartnode-simple]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=32gb:ncpus=64:mpiprocs=32 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::quartnode-simple]         2 jobs completed during this runtime
-
-
     [test::quartnode-simple]     All jobs simulated, stopping
-
-
     [test::quartnode-simple]   Maximum HPC resources required will be '-l select=2:mem=32gb:ncpus=64:mpiprocs=32 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::quartnode]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::quartnode]       Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::quartnode]         Simulating threadpool for 0:01:00
-
-
     [test::quartnode]           Calculate max instantaneous resources for this phase
-
-
     [test::quartnode]               Joining argpack '.*quartnode.*::select' from [our-config] into joinall
-
-
     [test::quartnode]               Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::quartnode]             Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::quartnode]           [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=64gb:ncpus=64:mpiprocs=32 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::quartnode]           2 jobs completed during this runtime
-
-
     [test::quartnode]       All jobs simulated, stopping
-
-
     [test::quartnode]     Maximum HPC resources required will be '-l select=2:mem=64gb:ncpus=64:mpiprocs=32 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::fullnode-simple]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::fullnode-simple]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::fullnode-simple]       Simulating threadpool for 0:01:00
-
-
     [test::fullnode-simple]         Calculate max instantaneous resources for this phase
-
-
     [test::fullnode-simple]             Joining argpack '.*fullnode.*::select'  from [our-config] into joinall
-
-
     [test::fullnode-simple]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::fullnode-simple]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::fullnode-simple]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::fullnode-simple]         2 jobs completed during this runtime
-
-
     [test::fullnode-simple]     All jobs simulated, stopping
-
-
     [test::fullnode-simple]   Maximum HPC resources required will be '-l select=2:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::fullnode-double]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::fullnode-double]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::fullnode-double]       Simulating threadpool for 0:01:00
-
-
     [test::fullnode-double]         Calculate max instantaneous resources for this phase
-
-
-    [test::fullnode-double]             Joining argpack '.*fullnode.*::select'  from [our-config.fullnode-double, our-config] into joinall
-
-
+    [test::fullnode-double]             Joining argpack '.*fullnode.*::select'  from [our-config, our-config.fullnode-double] into joinall
     [test::fullnode-double]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::fullnode-double]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::fullnode-double]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::fullnode-double]         2 jobs completed during this runtime
-
-
     [test::fullnode-double]     All jobs simulated, stopping
-
-
     [test::fullnode-double]   Maximum HPC resources required will be '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [file::our-config]  Calculating expected runtime of tests across 4 workers [pool size]
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 0] Resources for [  quartnode-simple,        quartnode,  fullnode-simple,  fullnode-double ] : '-l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      4 jobs completed during this runtime
-
-
     [file::our-config]  Maximum calculated resources for running all tests is '-l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy'
-
-
     [file::our-config]  Maximum calculated timelimit for running all tests is '00:01:00'
-
-
     [file::our-config]  Using current file as launch executable : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [file::our-config]  Setting keyphrase for passing to internally defined one
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Preparing working directory
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Checking if results wait is required...
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   Final results will wait for all jobs complete
-
-
     [step::submit]      Preparing working directory
-
-
     [step::submit]        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]        Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]      Submitting step submit...
-
-
     [step::submit]        Gathering HPC argument packs...
-
-
     [step::submit]          From [join] adding HPC argument pack 'select' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'select'   : 10
-
-
     [step::submit]              From join adding resource 'mem'      : 608gb
-
-
     [step::submit]              From join adding resource 'ncpus'    : 640
-
-
     [step::submit]              From join adding resource 'mpiprocs' : 320
-
-
     [step::submit]          Final argpack output for select : '-l select=10:mem=608gb:ncpus=640:mpiprocs=320'
-
-
     [step::submit]          From [join] adding HPC argument pack 'priority' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'job_priority' : economy
-
-
     [step::submit]          Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::submit]        Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [step::submit]        Running command:
-
-
     [step::submit]          qsub -l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 12 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2
-
-
     [step::submit]        *************** START submit  ***************
-
-
     
-
-
     [step::submit]        Doing dry-run, no ouptut
-
-
     
-
-
     [step::submit]        ***************  STOP submit  ***************
-
-
     [step::submit]        Finding job ID in "12345"
-
-
     [step::submit]      Finished submitting step submit
-
-
     
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Checking remaining steps...
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] No remaining steps, test submission complete
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Doing dry-run, assumed complete
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Outputting results...
-
-
     [step::submit]      Results for submit
-
-
     [step::submit]        Doing dry-run, assumed success
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Writing relevant logfiles to view in master log file : 
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.log
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] [SUCCESS] : Test joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double completed successfully
-
-
     [file::our-config]  Joined HPC tests complete, above success only means tests managed to complete, please see logs for per-test success
-
-
     [file::our-config]  Post-processing all test results...
-
-
     [file::our-config]  Doing dry-run, assumed success
 
 
@@ -2622,341 +1170,117 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Computing maximum HPC resources of tests...
-
-
     [file::our-config]  Accumulate maximum HPC resources per test...
-
-
     [test::quartnode-simple]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::quartnode-simple]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::quartnode-simple]       Simulating threadpool for 0:01:00
-
-
     [test::quartnode-simple]         Calculate max instantaneous resources for this phase
-
-
-    [test::quartnode-simple]             Joining argpack '.*quartnode.*::select' from [our-config.quartnode-simple, our-config] into joinall
-
-
+    [test::quartnode-simple]             Joining argpack '.*quartnode.*::select' from [our-config, our-config.quartnode-simple] into joinall
     [test::quartnode-simple]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::quartnode-simple]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::quartnode-simple]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=32gb:ncpus=64:mpiprocs=32 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::quartnode-simple]         2 jobs completed during this runtime
-
-
     [test::quartnode-simple]     All jobs simulated, stopping
-
-
     [test::quartnode-simple]   Maximum HPC resources required will be '-l select=2:mem=32gb:ncpus=64:mpiprocs=32 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::quartnode]     Computing maximum HPC resources per runnable step phase...
-
-
     [test::quartnode]       Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::quartnode]         Simulating threadpool for 0:01:00
-
-
     [test::quartnode]           Calculate max instantaneous resources for this phase
-
-
     [test::quartnode]               Joining argpack '.*quartnode.*::select' from [our-config] into joinall
-
-
     [test::quartnode]               Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::quartnode]             Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::quartnode]           [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=64gb:ncpus=64:mpiprocs=32 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::quartnode]           2 jobs completed during this runtime
-
-
     [test::quartnode]       All jobs simulated, stopping
-
-
     [test::quartnode]     Maximum HPC resources required will be '-l select=2:mem=64gb:ncpus=64:mpiprocs=32 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::fullnode-simple]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::fullnode-simple]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::fullnode-simple]       Simulating threadpool for 0:01:00
-
-
     [test::fullnode-simple]         Calculate max instantaneous resources for this phase
-
-
     [test::fullnode-simple]             Joining argpack '.*fullnode.*::select'  from [our-config] into joinall
-
-
     [test::fullnode-simple]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::fullnode-simple]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::fullnode-simple]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=2:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::fullnode-simple]         2 jobs completed during this runtime
-
-
     [test::fullnode-simple]     All jobs simulated, stopping
-
-
     [test::fullnode-simple]   Maximum HPC resources required will be '-l select=2:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [test::fullnode-double]   Computing maximum HPC resources per runnable step phase...
-
-
     [test::fullnode-double]     Calculating expected runtime of steps across 2 thread workers [threadpool size]
-
-
     [test::fullnode-double]       Simulating threadpool for 0:01:00
-
-
     [test::fullnode-double]         Calculate max instantaneous resources for this phase
-
-
     [test::fullnode-double]             Joining argpack '.*fullnode.*::select'  from [our-config, our-config.fullnode-double] into joinall
-
-
     [test::fullnode-double]             Joining argpack 'priority'              from [our-config] into joinall
-
-
     [test::fullnode-double]           Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [test::fullnode-double]         [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
-
-
     [test::fullnode-double]         2 jobs completed during this runtime
-
-
     [test::fullnode-double]     All jobs simulated, stopping
-
-
     [test::fullnode-double]   Maximum HPC resources required will be '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy' with timelimit '00:01:00'
-
-
     [file::our-config]  Calculating expected runtime of tests across 4 workers [pool size]
-
-
     [file::our-config]    Simulating threadpool for 0:01:00
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]        Joining argpack 'select'   from [join] into joinall
-
-
     [file::our-config]        Joining argpack 'priority' from [join] into joinall
-
-
     [file::our-config]      Unsure how to operate on resources economy and economy together, defaulting to economy
-
-
     [file::our-config]      [PHASE 0] Resources for [  quartnode-simple,        quartnode,  fullnode-simple,  fullnode-double ] : '-l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy', timelimit = 0:01:00
-
-
     [file::our-config]      4 jobs completed during this runtime
-
-
     [file::our-config]  Maximum calculated resources for running all tests is '-l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy'
-
-
     [file::our-config]  Maximum calculated timelimit for running all tests is '00:01:00'
-
-
     [file::our-config]  Requested override of resources with '{"select":{"-l ":{"select":7,"mem":"128GB","ncpus":128,"mpiprocs":128}}}'
-
-
     [file::our-config]    New maximum resources for running all tests is '-l select=7:mem=128GB:ncpus=128:mpiprocs=128 -l job_priority=economy'
-
-
     [file::our-config]  Using current file as launch executable : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [file::our-config]  Setting keyphrase for passing to internally defined one
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Preparing working directory
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Checking if results wait is required...
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   Final results will wait for all jobs complete
-
-
     [step::submit]      Preparing working directory
-
-
     [step::submit]        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]        Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::submit]      Submitting step submit...
-
-
     [step::submit]        Gathering HPC argument packs...
-
-
     [step::submit]          From [cli] adding HPC argument pack 'select' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From cli adding resource 'select'   : 7
-
-
     [step::submit]              From cli adding resource 'mem'      : 128GB
-
-
     [step::submit]              From cli adding resource 'ncpus'    : 128
-
-
     [step::submit]              From cli adding resource 'mpiprocs' : 128
-
-
     [step::submit]          Final argpack output for select : '-l select=7:mem=128GB:ncpus=128:mpiprocs=128'
-
-
     [step::submit]          From [join] adding HPC argument pack 'priority' :
-
-
     [step::submit]            Adding option '-l '
-
-
     [step::submit]              From join adding resource 'job_priority' : economy
-
-
     [step::submit]          Final argpack output for priority : '-l job_priority=economy'
-
-
     [step::submit]        Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
-
-
     [step::submit]        Running command:
-
-
     [step::submit]          qsub -l select=7:mem=128GB:ncpus=128:mpiprocs=128 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 12 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2
-
-
     [step::submit]        *************** START submit  ***************
-
-
     
-
-
     [step::submit]        Doing dry-run, no ouptut
-
-
     
-
-
     [step::submit]        ***************  STOP submit  ***************
-
-
     [step::submit]        Finding job ID in "12345"
-
-
     [step::submit]      Finished submitting step submit
-
-
     
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Checking remaining steps...
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] No remaining steps, test submission complete
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Doing dry-run, assumed complete
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Outputting results...
-
-
     [step::submit]      Results for submit
-
-
     [step::submit]        Doing dry-run, assumed success
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] Writing relevant logfiles to view in master log file : 
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double]   /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.log
-
-
     [test::joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double] [SUCCESS] : Test joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double completed successfully
-
-
     [file::our-config]  Joined HPC tests complete, above success only means tests managed to complete, please see logs for per-test success
-
-
     [file::our-config]  Post-processing all test results...
-
-
     [file::our-config]  Doing dry-run, assumed success
 
 

--- a/tutorials/AdvancedTestConfig_host_specific.md
+++ b/tutorials/AdvancedTestConfig_host_specific.md
@@ -107,53 +107,21 @@ $1/../.ci/runner.py $1/../our-config.json -h | \
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     usage: runner.py [-h] [-t TESTS [TESTS ...]] [-s {PBS,SLURM,LOCAL}]
-
-
                      [-a ACCOUNT] [-d DIROFFSET] [-j [JOINHPC]]
-
-
                      [-alt [ALTDIRS ...]] [-l LABELLENGTH] [-g GLOBALPREFIX]
-
-
                      [-dry] [-nf] [-nw] [-np] [-k KEY] [-p POOL] [-tp THREADPOOL]
-
-
                      [-r REDIRECT] [-i] [-ff FORCEFQDN] [-fs]
-
-
                      testsConfig
-
-
     
-
-
     positional arguments:
-
-
       testsConfig           JSON file defining set of tests
-
-
     
-
-
     options:
-
-
     ...
-
-
       -ff FORCEFQDN, --forceFQDN FORCEFQDN
-
-
                             Force the selection of host-specific "submit_options" to use input as the assumed FQDN
-
-
     ...
 
 Let's start with a small set of `"submit_options"` that will be our defaults :
@@ -186,161 +154,57 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "LOCAL",
-
-
         "timelimit"  : "00:01:00",
-
-
         "arguments"  :
-
-
         {
-
-
           "data_path" : [ "-p", "/some/local/path/" ]
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0-less-nodes] Preparing working directory
-
-
     [step::our-step0-less-nodes]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes] Submitting step our-step0-less-nodes...
-
-
     [step::our-step0-less-nodes]   Gathering argument packs...
-
-
     [step::our-step0-less-nodes]     From our-config adding arguments pack 'data_path' : ['-p', '/some/local/path/']
-
-
     [step::our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0-less-nodes]   Running command:
-
-
     [step::our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /some/local/path/
-
-
     [step::our-step0-less-nodes]   ***************START our-step0-less-nodes***************
-
-
     
-
-
     -p /some/local/path/
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0-less-nodes]   ***************STOP our-step0-less-nodes***************
-
-
     [step::our-step0-less-nodes] Finished submitting step our-step0-less-nodes
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0-less-nodes] Results for our-step0-less-nodes
-
-
     [step::our-step0-less-nodes]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log
-
-
     [step::our-step0-less-nodes]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0-less-nodes]   [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -381,182 +245,64 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "LOCAL",
-
-
         "timelimit"  : "00:01:00",
-
-
         "arguments"  :
-
-
         {
-
-
           "data_path" : [ "-p", "/some/local/path/" ]
-
-
         },
-
-
         "tutorials" :
-
-
         {
-
-
           "arguments" :
-
-
           {
-
-
             "data_path" : [ "-p", "/opt/data/path" ]
-
-
           }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0-less-nodes] Preparing working directory
-
-
     [step::our-step0-less-nodes]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes] Submitting step our-step0-less-nodes...
-
-
     [step::our-step0-less-nodes]   Gathering argument packs...
-
-
     [step::our-step0-less-nodes]     From our-config adding arguments pack 'data_path' : ['-p', '/opt/data/path']
-
-
     [step::our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0-less-nodes]   Running command:
-
-
     [step::our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /opt/data/path
-
-
     [step::our-step0-less-nodes]   ***************START our-step0-less-nodes***************
-
-
     
-
-
     -p /opt/data/path
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0-less-nodes]   ***************STOP our-step0-less-nodes***************
-
-
     [step::our-step0-less-nodes] Finished submitting step our-step0-less-nodes
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0-less-nodes] Results for our-step0-less-nodes
-
-
     [step::our-step0-less-nodes]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log
-
-
     [step::our-step0-less-nodes]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0-less-nodes]   [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -607,212 +353,74 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "LOCAL",
-
-
         "timelimit"  : "00:01:00",
-
-
         "arguments"  :
-
-
         {
-
-
           "data_path" : [ "-p", "/some/local/path/" ]
-
-
         },
-
-
         "tutorials" :
-
-
         {
-
-
           "arguments" :
-
-
           {
-
-
             "data_path" : [ "-p", "/opt/data/path" ]
-
-
           }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "tutorials" :
-
-
           {
-
-
             "arguments" :
-
-
             {
-
-
               "data_path" : [ "-p", "/home/user/data/path" ]
-
-
             }
-
-
           }
-
-
         },
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0-less-nodes] Preparing working directory
-
-
     [step::our-step0-less-nodes]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes] Submitting step our-step0-less-nodes...
-
-
     [step::our-step0-less-nodes]   Gathering argument packs...
-
-
     [step::our-step0-less-nodes]     From our-config.our-test adding arguments pack 'data_path' : ['-p', '/home/user/data/path']
-
-
     [step::our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0-less-nodes]   Running command:
-
-
     [step::our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /home/user/data/path
-
-
     [step::our-step0-less-nodes]   ***************START our-step0-less-nodes***************
-
-
     
-
-
     -p /home/user/data/path
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0-less-nodes]   ***************STOP our-step0-less-nodes***************
-
-
     [step::our-step0-less-nodes] Finished submitting step our-step0-less-nodes
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0-less-nodes] Results for our-step0-less-nodes
-
-
     [step::our-step0-less-nodes]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log
-
-
     [step::our-step0-less-nodes]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0-less-nodes]   [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 

--- a/tutorials/AdvancedTestConfig_hpc_argpacks.md
+++ b/tutorials/AdvancedTestConfig_hpc_argpacks.md
@@ -100,56 +100,22 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing to run multiple tests
-
-
     [file::our-config]    Automatically redirecting our-test to /home/runner/work/hpc-workflows/hpc-workflows/our-test_stdout.log
-
-
     [file::our-config]  Spawning process pool of size 4 to perform 1 tests
-
-
     [file::our-config]    Launching test our-test
-
-
     [file::our-config]    Waiting for tests to complete - BE PATIENT
-
-
     [file::our-config]    [SUCCESS] : Test our-test reported success
-
-
     [file::our-config]  Test suite complete, writing test results to master log file : 
-
-
     [file::our-config]    /home/runner/work/hpc-workflows/hpc-workflows/our-config.log
-
-
     [file::our-config]  [SUCCESS] : All tests passed
 
 
@@ -164,107 +130,39 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -293,89 +191,33 @@ echo ""
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS"
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     Traceback (most recent call last):
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 707, in <module>
-
-
         main()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 701, in main
-
-
         success, tests, logs = runSuite( options )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 510, in runSuite
-
-
         success, logs = testSuite.run( options.tests )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 430, in run
-
-
         self.tests_[test].validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
-
-
         step.validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
-
-
         self.submitOptions_.validate( print=self.log )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 154, in validate
-
-
         errMsg = "Error: Invalid submission options [Missing {opt}]\n{opts}".format( opt=err, opts=self.submitOptions_ )
-
-
     AttributeError: 'SubmitOptions' object has no attribute 'submitOptions_'
-
-
     
 
 
@@ -404,89 +246,33 @@ echo ""
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS"
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     Traceback (most recent call last):
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 707, in <module>
-
-
         main()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 701, in main
-
-
         success, tests, logs = runSuite( options )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 510, in runSuite
-
-
         success, logs = testSuite.run( options.tests )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 430, in run
-
-
         self.tests_[test].validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
-
-
         step.validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
-
-
         self.submitOptions_.validate( print=self.log )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 154, in validate
-
-
         errMsg = "Error: Invalid submission options [Missing {opt}]\n{opts}".format( opt=err, opts=self.submitOptions_ )
-
-
     AttributeError: 'SubmitOptions' object has no attribute 'submitOptions_'
-
-
     
 
 
@@ -517,134 +303,48 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00"
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -740,158 +440,56 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "node_select" : { "-l" : {} }
-
-
         }
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering HPC argument packs...
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'node_select' :
-
-
     [step::our-step0]         Adding option '-l'
-
-
     [step::our-step0]       Final argpack output for node_select : '-l'
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -l -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -927,161 +525,57 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "select" : { "-l" : { "select" : 1 } }
-
-
         }
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering HPC argument packs...
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step0]         Adding option '-l'
-
-
     [step::our-step0]           From our-config adding resource 'select' : 1
-
-
     [step::our-step0]       Final argpack output for select : '-lselect=1'
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -lselect=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -1142,161 +636,57 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "select" : { "-l " : { "select" : 1 } }
-
-
         }
-
-
       },
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering HPC argument packs...
-
-
     [step::our-step0]       From [our-config] adding HPC argument pack 'select' :
-
-
     [step::our-step0]         Adding option '-l '
-
-
     [step::our-step0]           From our-config adding resource 'select' : 1
-
-
     [step::our-step0]       Final argpack output for select : '-l select=1'
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Finding job ID in "12345"
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -1354,179 +744,63 @@ echo ""
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           "select" : { "-l " : { ".*less-nodes.*::select" : 1 } }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "hpc_arguments" : 
-
-
           {
-
-
             "select" : { "-l " : { ".*more-nodes.*::select" : 2 } }
-
-
           }
-
-
         },
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [test::our-test]    Argument pack select at our-config.our-test '.*more-nodes.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
-
-
     Traceback (most recent call last):
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 707, in <module>
-
-
         main()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 701, in main
-
-
         success, tests, logs = runSuite( options )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 502, in runSuite
-
-
         testSuite = Suite( 
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 39, in __init__
-
-
         super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 32, in __init__
-
-
         self.parse()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 65, in parse
-
-
         self.parseSpecificOptions()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 52, in parseSpecificOptions
-
-
         self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 30, in __init__
-
-
         super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 32, in __init__
-
-
         self.parse()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 60, in parse
-
-
         self.submitOptions_.update( SubmitOptions( self.options_[ key ], origin=self.ancestry(), print=self.log ), print=self.log )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 126, in update
-
-
         if rhs.hpcArguments_.arguments_         : self.hpcArguments_.update( rhs.hpcArguments_, print=print )    
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/HpcArgpacks.py", line 35, in update
-
-
         self.nestedArguments_[key].update( rhs.nestedArguments_[key], print )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitArgpacks.py", line 47, in update
-
-
         self.validate( print=print )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitArgpacks.py", line 86, in validate
-
-
         raise Exception( err )
-
-
     Exception: Argument pack select at our-config.our-test '.*more-nodes.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
-
-
     
 
 
@@ -1570,191 +844,67 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           ".*less-nodes.*::select" : { "-l " : { "select" : 1 } }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "hpc_arguments" : 
-
-
           {
-
-
             ".*more-nodes.*::select" : { "-l " : { "select" : 2 } }
-
-
           }
-
-
         },
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      Final results will wait for all jobs complete
-
-
     [step::our-step0-less-nodes] Preparing working directory
-
-
     [step::our-step0-less-nodes]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes] Submitting step our-step0-less-nodes...
-
-
     [step::our-step0-less-nodes]   Gathering HPC argument packs...
-
-
     [step::our-step0-less-nodes]     From [our-config] adding HPC argument pack '.*less-nodes.*::select' :
-
-
     [step::our-step0-less-nodes]       Adding option '-l '
-
-
     [step::our-step0-less-nodes]         From our-config adding resource 'select' : 1
-
-
     [step::our-step0-less-nodes]     Final argpack output for .*less-nodes.*::select : '-l select=1'
-
-
     [step::our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0-less-nodes]   Running command:
-
-
     [step::our-step0-less-nodes]     qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0-less-nodes -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes]   ***************START our-step0-less-nodes***************
-
-
     
-
-
     [step::our-step0-less-nodes]   Doing dry-run, no ouptut
-
-
     
-
-
     [step::our-step0-less-nodes]   ***************STOP our-step0-less-nodes***************
-
-
     [step::our-step0-less-nodes]   Finding job ID in "12345"
-
-
     [step::our-step0-less-nodes] Finished submitting step our-step0-less-nodes
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Doing dry-run, assumed complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0-less-nodes] Results for our-step0-less-nodes
-
-
     [step::our-step0-less-nodes]   Doing dry-run, assumed success
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -1797,158 +947,56 @@ echo ""
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "submit_options" :
-
-
       {
-
-
         "submission" : "PBS",
-
-
         "queue"      : "economy",
-
-
         "timelimit"  : "00:01:00",
-
-
         "hpc_arguments" :
-
-
         {
-
-
           ".*less-nodes.*::select" : { "-l " : { "select" : 1 } }
-
-
         }
-
-
       },
-
-
       "our-test" :
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "hpc_arguments" : 
-
-
           {
-
-
             ".*our.*::select" : { "-l " : { "select" : 2 } }
-
-
           }
-
-
         },
-
-
         "steps" : { "our-step0-less-nodes" : { "command" : "./tests/scripts/echo_normal.sh" } }
-
-
       }
-
-
     }
-
-
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0-less-nodes] Argument pack select at our-config.our-test '.*our.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
-
-
     Traceback (most recent call last):
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 707, in <module>
-
-
         main()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 701, in main
-
-
         success, tests, logs = runSuite( options )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 510, in runSuite
-
-
         success, logs = testSuite.run( options.tests )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 430, in run
-
-
         self.tests_[test].validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
-
-
         step.validate()
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
-
-
         self.submitOptions_.validate( print=self.log )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 159, in validate
-
-
         self.hpcArguments_.selectAncestrySpecificSubmitArgpacks( print=print )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/HpcArgpacks.py", line 69, in selectAncestrySpecificSubmitArgpacks
-
-
         finalHpcArgpacks.validate( print=print )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/HpcArgpacks.py", line 42, in validate
-
-
         super().validate( print )
-
-
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitArgpacks.py", line 86, in validate
-
-
         raise Exception( err )
-
-
     Exception: Argument pack select at our-config.our-test '.*our.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
-
-
     
 
 

--- a/tutorials/AdvancedTestConfig_regex_argpacks.md
+++ b/tutorials/AdvancedTestConfig_regex_argpacks.md
@@ -809,13 +809,13 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::build-omp-fp32-ftA]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
 
 
+    [test::regex-test]  Checking remaining steps...
+
+
     [step::build-omp-fp32-ftA]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
 
 
     [step::build-omp-fp32-ftA] Submitting step build-omp-fp32-ftA...
-
-
-    [test::regex-test]  Checking remaining steps...
 
 
     [step::build-omp-fp32-ftA]   Gathering argument packs...

--- a/tutorials/AdvancedTestConfig_regex_argpacks.md
+++ b/tutorials/AdvancedTestConfig_regex_argpacks.md
@@ -118,68 +118,26 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "regex-test" : 
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "arguments" :
-
-
           {
-
-
             ".*send.*::send_prefix" : [ "[send] " ],
-
-
             ".*recv.*::recv_prefix" : [ "[recv] " ]
-
-
           }
-
-
         },
-
-
         "steps" :
-
-
         {
-
-
           "send-step0" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "Hello!" ] },
-
-
           "recv-step1" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "Hello back!" ] },
-
-
           "send-step2" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "Ping 1" ] },
-
-
           "send-step3" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "Ping 2" ] },
-
-
           "recv-step4" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "Pings received" ] }
-
-
         }
-
-
       }
-
-
     }
 
 
@@ -192,365 +150,125 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Preparing working directory
-
-
     [test::regex-test]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Checking if results wait is required...
-
-
     [test::regex-test]    No HPC submissions, no results waiting required
-
-
     [step::send-step0]  Preparing working directory
-
-
     [step::send-step0]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step0]    Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step0]  Submitting step send-step0...
-
-
     [step::send-step0]    Gathering argument packs...
-
-
     [step::send-step0]      From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
-
-
     [step::send-step0]    Script : ./tests/scripts/echo_normal.sh
-
-
     [step::send-step0]    Running command:
-
-
     [step::send-step0]      /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows Hello! "[send] "
-
-
     [step::send-step0]    ***************START send-step0***************
-
-
     
-
-
     Hello! [send]
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::send-step0]    ***************STOP send-step0***************
-
-
     [step::send-step0]  Finished submitting step send-step0
-
-
     
-
-
     [step::recv-step1]  Preparing working directory
-
-
     [step::recv-step1]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Checking remaining steps...
-
-
     [step::recv-step1]    Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::recv-step1]  Submitting step recv-step1...
-
-
     [step::recv-step1]    Gathering argument packs...
-
-
     [step::recv-step1]      From our-config.regex-test adding arguments pack '.*recv.*::recv_prefix' : ['[recv] ']
-
-
     [step::recv-step1]    Script : ./tests/scripts/echo_normal.sh
-
-
     [step::recv-step1]    Running command:
-
-
     [step::recv-step1]      /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Hello back!" "[recv] "
-
-
     [step::recv-step1]    ***************START recv-step1***************
-
-
     
-
-
     Hello back! [recv]
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::recv-step1]    ***************STOP recv-step1***************
-
-
     [step::recv-step1]  Finished submitting step recv-step1
-
-
     
-
-
     [step::send-step2]  Preparing working directory
-
-
     [step::send-step2]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step2]    Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step2]  Submitting step send-step2...
-
-
     [step::send-step2]    Gathering argument packs...
-
-
     [step::send-step2]      From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
-
-
     [step::send-step2]    Script : ./tests/scripts/echo_normal.sh
-
-
     [step::send-step2]    Running command:
-
-
     [step::send-step2]      /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Ping 1" "[send] "
-
-
     [step::send-step2]    ***************START send-step2***************
-
-
     
-
-
     Ping 1 [send]
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::send-step2]    ***************STOP send-step2***************
-
-
     [step::send-step2]  Finished submitting step send-step2
-
-
     
-
-
     [step::send-step3]  Preparing working directory
-
-
     [step::send-step3]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step3]    Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::send-step3]  Submitting step send-step3...
-
-
     [step::send-step3]    Gathering argument packs...
-
-
     [step::send-step3]      From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
-
-
     [step::send-step3]    Script : ./tests/scripts/echo_normal.sh
-
-
     [step::send-step3]    Running command:
-
-
     [step::send-step3]      /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Ping 2" "[send] "
-
-
     [step::send-step3]    ***************START send-step3***************
-
-
     
-
-
     Ping 2 [send]
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::send-step3]    ***************STOP send-step3***************
-
-
     [step::send-step3]  Finished submitting step send-step3
-
-
     
-
-
     [step::recv-step4]  Preparing working directory
-
-
     [step::recv-step4]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::recv-step4]    Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::recv-step4]  Submitting step recv-step4...
-
-
     [step::recv-step4]    Gathering argument packs...
-
-
     [step::recv-step4]      From our-config.regex-test adding arguments pack '.*recv.*::recv_prefix' : ['[recv] ']
-
-
     [step::recv-step4]    Script : ./tests/scripts/echo_normal.sh
-
-
     [step::recv-step4]    Running command:
-
-
     [step::recv-step4]      /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Pings received" "[recv] "
-
-
     [step::recv-step4]    ***************START recv-step4***************
-
-
     
-
-
     Pings received [recv]
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::recv-step4]    ***************STOP recv-step4***************
-
-
     [step::recv-step4]  Finished submitting step recv-step4
-
-
     
-
-
     [test::regex-test]  No remaining steps, test submission complete
-
-
     [test::regex-test]  Outputting results...
-
-
     [step::send-step0]  Results for send-step0
-
-
     [step::send-step0]    Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.send-step0.log
-
-
     [step::send-step0]    Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::send-step0]    [SUCCESS]
-
-
     [step::recv-step1]  Results for recv-step1
-
-
     [step::recv-step1]    Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.recv-step1.log
-
-
     [step::recv-step1]    Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::recv-step1]    [SUCCESS]
-
-
     [step::send-step2]  Results for send-step2
-
-
     [step::send-step2]    Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.send-step2.log
-
-
     [step::send-step2]    Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::send-step2]    [SUCCESS]
-
-
     [step::send-step3]  Results for send-step3
-
-
     [step::send-step3]    Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.send-step3.log
-
-
     [step::send-step3]    Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::send-step3]    [SUCCESS]
-
-
     [step::recv-step4]  Results for recv-step4
-
-
     [step::recv-step4]    Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.recv-step4.log
-
-
     [step::recv-step4]    Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::recv-step4]    [SUCCESS]
-
-
     [test::regex-test]  Writing relevant logfiles to view in master log file : 
-
-
     [test::regex-test]    /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.log
-
-
     [test::regex-test]  [SUCCESS] : Test regex-test completed successfully
 
 
@@ -622,92 +340,34 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "regex-test" : 
-
-
       {
-
-
         "submit_options" :
-
-
         {
-
-
           "arguments" :
-
-
           {
-
-
             ".*dbg.*::dbg_flag" : [ "-d" ],
-
-
             ".*mpi.*::mpi_flag" : [ "--mpi" ],
-
-
             ".*omp.*::omp_flag" : [ "--omp" ],
-
-
             ".*fp64.*::fp64_flag" : [ "--double" ],
-
-
             ".*ft[^A]*A.*::feature_a" : [ "-a" ],
-
-
             ".*ft[^B]*B.*::feature_b" : [ "-b" ],
-
-
             ".*ft[^C]*C.*::feature_b" : [ "-c" ]
-
-
           }
-
-
         },
-
-
         "steps" :
-
-
         {
-
-
           "build-omp-fp32-dbg"  : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-omp-fp32-dbg" ] },
-
-
           "build-omp-fp32-ftA"  : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-omp-fp32-ftA" ] },
-
-
           "build-omp-fp32-ftAB" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-omp-fp32-ftAB" ] },
-
-
           "build-omp-fp32-ftBC" : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-omp-fp32-ftBC" ] },
-
-
           "build-omp-fp64-ftB"  : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-omp-fp64-ftB" ] },
-
-
           "build-mpi-fp32-dbg"  : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-mpi-fp32-dbg" ] },
-
-
           "build-mpi-fp32"      : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-mpi-fp32" ] },
-
-
           "build-mpi-fp64"      : { "command" : "./tests/scripts/echo_normal.sh", "arguments" : [ "-o", "build-mpi-fp64" ] }
-
-
         }
-
-
       }
-
-
     }
 
 
@@ -720,584 +380,198 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Preparing working directory
-
-
     [test::regex-test]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Checking if results wait is required...
-
-
     [test::regex-test]    No HPC submissions, no results waiting required
-
-
     [step::build-omp-fp32-dbg] Preparing working directory
-
-
     [step::build-omp-fp32-dbg]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-dbg]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-dbg] Submitting step build-omp-fp32-dbg...
-
-
     [step::build-omp-fp32-dbg]   Gathering argument packs...
-
-
     [step::build-omp-fp32-dbg]     From our-config.regex-test adding arguments pack '.*dbg.*::dbg_flag' : ['-d']
-
-
     [step::build-omp-fp32-dbg]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag' : ['--omp']
-
-
     [step::build-omp-fp32-dbg]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-omp-fp32-dbg]   Running command:
-
-
     [step::build-omp-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-dbg -d --omp
-
-
     [step::build-omp-fp32-dbg]   ***************START build-omp-fp32-dbg***************
-
-
     
-
-
     -o build-omp-fp32-dbg -d --omp
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-omp-fp32-dbg]   ***************STOP build-omp-fp32-dbg***************
-
-
     [step::build-omp-fp32-dbg] Finished submitting step build-omp-fp32-dbg
-
-
     
-
-
-    [step::build-omp-fp32-ftA] Preparing working directory
-
-
-    [step::build-omp-fp32-ftA]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::regex-test]  Checking remaining steps...
-
-
+    [step::build-omp-fp32-ftA] Preparing working directory
+    [step::build-omp-fp32-ftA]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
     [step::build-omp-fp32-ftA]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-ftA] Submitting step build-omp-fp32-ftA...
-
-
     [step::build-omp-fp32-ftA]   Gathering argument packs...
-
-
     [step::build-omp-fp32-ftA]     From our-config.regex-test adding arguments pack '.*ft[^A]*A.*::feature_a' : ['-a']
-
-
     [step::build-omp-fp32-ftA]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
-
-
     [step::build-omp-fp32-ftA]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-omp-fp32-ftA]   Running command:
-
-
     [step::build-omp-fp32-ftA]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftA -a --omp
-
-
     [step::build-omp-fp32-ftA]   ***************START build-omp-fp32-ftA***************
-
-
     
-
-
     -o build-omp-fp32-ftA -a --omp
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-omp-fp32-ftA]   ***************STOP build-omp-fp32-ftA***************
-
-
     [step::build-omp-fp32-ftA] Finished submitting step build-omp-fp32-ftA
-
-
     
-
-
     [step::build-omp-fp32-ftAB] Preparing working directory
-
-
     [step::build-omp-fp32-ftAB]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-ftAB]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-ftAB] Submitting step build-omp-fp32-ftAB...
-
-
     [step::build-omp-fp32-ftAB]   Gathering argument packs...
-
-
     [step::build-omp-fp32-ftAB]     From our-config.regex-test adding arguments pack '.*ft[^A]*A.*::feature_a' : ['-a']
-
-
     [step::build-omp-fp32-ftAB]     From our-config.regex-test adding arguments pack '.*ft[^B]*B.*::feature_b' : ['-b']
-
-
     [step::build-omp-fp32-ftAB]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
-
-
     [step::build-omp-fp32-ftAB]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-omp-fp32-ftAB]   Running command:
-
-
     [step::build-omp-fp32-ftAB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftAB -a -b --omp
-
-
     [step::build-omp-fp32-ftAB]   ***************START build-omp-fp32-ftAB***************
-
-
     
-
-
     -o build-omp-fp32-ftAB -a -b --omp
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-omp-fp32-ftAB]   ***************STOP build-omp-fp32-ftAB***************
-
-
     [step::build-omp-fp32-ftAB] Finished submitting step build-omp-fp32-ftAB
-
-
     
-
-
     [step::build-omp-fp32-ftBC] Preparing working directory
-
-
     [step::build-omp-fp32-ftBC]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-ftBC]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp32-ftBC] Submitting step build-omp-fp32-ftBC...
-
-
     [step::build-omp-fp32-ftBC]   Gathering argument packs...
-
-
     [step::build-omp-fp32-ftBC]     From our-config.regex-test adding arguments pack '.*ft[^B]*B.*::feature_b' : ['-b']
-
-
     [step::build-omp-fp32-ftBC]     From our-config.regex-test adding arguments pack '.*ft[^C]*C.*::feature_b' : ['-c']
-
-
     [step::build-omp-fp32-ftBC]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
-
-
     [step::build-omp-fp32-ftBC]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-omp-fp32-ftBC]   Running command:
-
-
     [step::build-omp-fp32-ftBC]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftBC -b -c --omp
-
-
     [step::build-omp-fp32-ftBC]   ***************START build-omp-fp32-ftBC***************
-
-
     
-
-
     -o build-omp-fp32-ftBC -b -c --omp
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-omp-fp32-ftBC]   ***************STOP build-omp-fp32-ftBC***************
-
-
     [step::build-omp-fp32-ftBC] Finished submitting step build-omp-fp32-ftBC
-
-
     
-
-
     [step::build-omp-fp64-ftB] Preparing working directory
-
-
     [step::build-omp-fp64-ftB]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp64-ftB]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-omp-fp64-ftB] Submitting step build-omp-fp64-ftB...
-
-
     [step::build-omp-fp64-ftB]   Gathering argument packs...
-
-
     [step::build-omp-fp64-ftB]     From our-config.regex-test adding arguments pack '.*ft[^B]*B.*::feature_b' : ['-b']
-
-
     [step::build-omp-fp64-ftB]     From our-config.regex-test adding arguments pack '.*fp64.*::fp64_flag'     : ['--double']
-
-
     [step::build-omp-fp64-ftB]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
-
-
     [step::build-omp-fp64-ftB]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-omp-fp64-ftB]   Running command:
-
-
     [step::build-omp-fp64-ftB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp64-ftB -b --double --omp
-
-
     [step::build-omp-fp64-ftB]   ***************START build-omp-fp64-ftB***************
-
-
     
-
-
     -o build-omp-fp64-ftB -b --double --omp
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-omp-fp64-ftB]   ***************STOP build-omp-fp64-ftB***************
-
-
     [step::build-omp-fp64-ftB] Finished submitting step build-omp-fp64-ftB
-
-
     
-
-
     [step::build-mpi-fp32-dbg] Preparing working directory
-
-
     [step::build-mpi-fp32-dbg]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp32-dbg]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp32-dbg] Submitting step build-mpi-fp32-dbg...
-
-
     [step::build-mpi-fp32-dbg]   Gathering argument packs...
-
-
     [step::build-mpi-fp32-dbg]     From our-config.regex-test adding arguments pack '.*dbg.*::dbg_flag' : ['-d']
-
-
     [step::build-mpi-fp32-dbg]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag' : ['--mpi']
-
-
     [step::build-mpi-fp32-dbg]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-mpi-fp32-dbg]   Running command:
-
-
     [step::build-mpi-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32-dbg -d --mpi
-
-
     [step::build-mpi-fp32-dbg]   ***************START build-mpi-fp32-dbg***************
-
-
     
-
-
     -o build-mpi-fp32-dbg -d --mpi
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-mpi-fp32-dbg]   ***************STOP build-mpi-fp32-dbg***************
-
-
     [step::build-mpi-fp32-dbg] Finished submitting step build-mpi-fp32-dbg
-
-
     
-
-
     [step::build-mpi-fp32] Preparing working directory
-
-
     [step::build-mpi-fp32]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp32]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp32] Submitting step build-mpi-fp32...
-
-
     [step::build-mpi-fp32]   Gathering argument packs...
-
-
     [step::build-mpi-fp32]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag' : ['--mpi']
-
-
     [step::build-mpi-fp32]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-mpi-fp32]   Running command:
-
-
     [step::build-mpi-fp32]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32 --mpi
-
-
     [step::build-mpi-fp32]   ***************START build-mpi-fp32***************
-
-
     
-
-
     -o build-mpi-fp32 --mpi
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-mpi-fp32]   ***************STOP build-mpi-fp32***************
-
-
     [step::build-mpi-fp32] Finished submitting step build-mpi-fp32
-
-
     
-
-
     [step::build-mpi-fp64] Preparing working directory
-
-
     [step::build-mpi-fp64]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp64]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::build-mpi-fp64] Submitting step build-mpi-fp64...
-
-
     [step::build-mpi-fp64]   Gathering argument packs...
-
-
     [step::build-mpi-fp64]     From our-config.regex-test adding arguments pack '.*fp64.*::fp64_flag' : ['--double']
-
-
     [step::build-mpi-fp64]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag'   : ['--mpi']
-
-
     [step::build-mpi-fp64]   Script : ./tests/scripts/echo_normal.sh
-
-
     [step::build-mpi-fp64]   Running command:
-
-
     [step::build-mpi-fp64]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp64 --double --mpi
-
-
     [step::build-mpi-fp64]   ***************START build-mpi-fp64***************
-
-
     
-
-
     -o build-mpi-fp64 --double --mpi
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::build-mpi-fp64]   ***************STOP build-mpi-fp64***************
-
-
     [step::build-mpi-fp64] Finished submitting step build-mpi-fp64
-
-
     
-
-
     [test::regex-test]  No remaining steps, test submission complete
-
-
     [test::regex-test]  Outputting results...
-
-
     [step::build-omp-fp32-dbg] Results for build-omp-fp32-dbg
-
-
     [step::build-omp-fp32-dbg]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-omp-fp32-dbg.log
-
-
     [step::build-omp-fp32-dbg]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-omp-fp32-dbg]   [SUCCESS]
-
-
     [step::build-omp-fp32-ftA] Results for build-omp-fp32-ftA
-
-
     [step::build-omp-fp32-ftA]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-omp-fp32-ftA.log
-
-
     [step::build-omp-fp32-ftA]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-omp-fp32-ftA]   [SUCCESS]
-
-
     [step::build-omp-fp32-ftAB] Results for build-omp-fp32-ftAB
-
-
     [step::build-omp-fp32-ftAB]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-omp-fp32-ftAB.log
-
-
     [step::build-omp-fp32-ftAB]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-omp-fp32-ftAB]   [SUCCESS]
-
-
     [step::build-omp-fp32-ftBC] Results for build-omp-fp32-ftBC
-
-
     [step::build-omp-fp32-ftBC]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-omp-fp32-ftBC.log
-
-
     [step::build-omp-fp32-ftBC]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-omp-fp32-ftBC]   [SUCCESS]
-
-
     [step::build-omp-fp64-ftB] Results for build-omp-fp64-ftB
-
-
     [step::build-omp-fp64-ftB]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-omp-fp64-ftB.log
-
-
     [step::build-omp-fp64-ftB]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-omp-fp64-ftB]   [SUCCESS]
-
-
     [step::build-mpi-fp32-dbg] Results for build-mpi-fp32-dbg
-
-
     [step::build-mpi-fp32-dbg]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-mpi-fp32-dbg.log
-
-
     [step::build-mpi-fp32-dbg]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-mpi-fp32-dbg]   [SUCCESS]
-
-
     [step::build-mpi-fp32] Results for build-mpi-fp32
-
-
     [step::build-mpi-fp32]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-mpi-fp32.log
-
-
     [step::build-mpi-fp32]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-mpi-fp32]   [SUCCESS]
-
-
     [step::build-mpi-fp64] Results for build-mpi-fp64
-
-
     [step::build-mpi-fp64]   Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.build-mpi-fp64.log
-
-
     [step::build-mpi-fp64]   Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::build-mpi-fp64]   [SUCCESS]
-
-
     [test::regex-test]  Writing relevant logfiles to view in master log file : 
-
-
     [test::regex-test]    /home/runner/work/hpc-workflows/hpc-workflows/our-config.regex-test.log
-
-
     [test::regex-test]  [SUCCESS] : Test regex-test completed successfully
 
 

--- a/tutorials/BasicTestConfig.md
+++ b/tutorials/BasicTestConfig.md
@@ -200,14 +200,8 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
-
-
     }
 
 
@@ -220,44 +214,18 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing to run multiple tests
-
-
     [file::our-config]    Automatically redirecting our-test to /home/runner/work/hpc-workflows/hpc-workflows/our-test_stdout.log
-
-
     [file::our-config]  Spawning process pool of size 4 to perform 1 tests
-
-
     [file::our-config]    Launching test our-test
-
-
     [file::our-config]    Waiting for tests to complete - BE PATIENT
-
-
     [file::our-config]    [SUCCESS] : Test our-test reported success
-
-
     [file::our-config]  Test suite complete, writing test results to master log file : 
-
-
     [file::our-config]    /home/runner/work/hpc-workflows/hpc-workflows/our-config.log
-
-
     [file::our-config]  [SUCCESS] : All tests passed
 
 
@@ -274,101 +242,37 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test --forceSingle # we could s
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     [step::our-step0]     Local step will be redirected to logfile /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -381,107 +285,39 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -514,44 +350,18 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "our-test" : 
-
-
       { 
-
-
         "steps" : 
-
-
         { 
-
-
           "our-step0" : 
-
-
           { 
-
-
             "command" : "./tests/scripts/echo_normal.sh",
-
-
             "arguments" : [ "foobar" ]
-
-
           }
-
-
         }
-
-
       }
-
-
     }
 
 
@@ -564,107 +374,39 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     foobar
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -701,62 +443,24 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
       "our-test" : 
-
-
       { 
-
-
         "steps" : 
-
-
         { 
-
-
           "our-step0" : 
-
-
           { 
-
-
             "command" : "./tests/scripts/echo_normal.sh",
-
-
             "arguments" : [ "foobar" ]
-
-
           },
-
-
           "our-step1" : 
-
-
           { 
-
-
             "command" : "./tests/scripts/echo_normal.sh",
-
-
             "arguments" : [ "why", "not more", "args?" ],
-
-
             "dependencies" : { "our-step0" : "afterany" }
-
-
           }
-
-
         }
-
-
       }
-
-
     }
 
 
@@ -767,170 +471,60 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     foobar
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Notifying children...
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [step::our-step1]   Preparing working directory
-
-
     [step::our-step1]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]   Submitting step our-step1...
-
-
     [step::our-step1]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step1]     Running command:
-
-
     [step::our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows why "not more" args?
-
-
     [step::our-step1]     ***************START our-step1***************
-
-
     
-
-
     why not more args?
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step1]     ***************STOP our-step1 ***************
-
-
     [step::our-step1]   Finished submitting step our-step1
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [step::our-step1]   Results for our-step1
-
-
     [step::our-step1]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step1.log
-
-
     [step::our-step1]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step1]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 
@@ -978,83 +572,31 @@ cat $1/../our-config.json
 ```
 
     /home/runner/work/hpc-workflows/hpc-workflows/our-config.json :
-
-
     {
-
-
      "our-test" : 
-
-
      { 
-
-
        "submit_options" :
-
-
        {
-
-
          "arguments" :
-
-
          {
-
-
            "our-default-argpack" : [ "foobar" ]
-
-
          }
-
-
        },
-
-
        "steps" : 
-
-
        { 
-
-
          "our-step0" : 
-
-
          { 
-
-
            "command" : "./tests/scripts/echo_normal.sh",
-
-
            "arguments" : [ "foobar" ]
-
-
          },
-
-
          "our-step1" : 
-
-
          { 
-
-
            "command" : "./tests/scripts/echo_normal.sh",
-
-
            "arguments" : [ "why", "not more", "args?" ],
-
-
            "dependencies" : { "our-step0" : "afterany" }
-
-
          }
-
-
        }
-
-
      }
-
-
     }
 
 
@@ -1068,182 +610,64 @@ rm $1/../our-config.json $1/../*.log
 ```
 
     Using Python version : 
-
-
     3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
-
-
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
-
-
     [file::our-config]  Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [file::our-config]  Preparing working directory
-
-
     [file::our-config]    Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Preparing working directory
-
-
     [test::our-test]      Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [test::our-test]    Checking if results wait is required...
-
-
     [test::our-test]      No HPC submissions, no results waiting required
-
-
     [step::our-step0]   Preparing working directory
-
-
     [step::our-step0]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step0]   Submitting step our-step0...
-
-
     [step::our-step0]     Gathering argument packs...
-
-
     [step::our-step0]       From our-config.our-test adding arguments pack 'our-default-argpack' : ['foobar']
-
-
     [step::our-step0]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step0]     Running command:
-
-
     [step::our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar foobar
-
-
     [step::our-step0]     ***************START our-step0***************
-
-
     
-
-
     foobar foobar
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step0]     ***************STOP our-step0 ***************
-
-
     [step::our-step0]     Notifying children...
-
-
     [step::our-step0]   Finished submitting step our-step0
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [step::our-step1]   Preparing working directory
-
-
     [step::our-step1]     Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]     Current directory : /home/runner/work/hpc-workflows/hpc-workflows
-
-
     [step::our-step1]   Submitting step our-step1...
-
-
     [step::our-step1]     Gathering argument packs...
-
-
     [step::our-step1]       From our-config.our-test adding arguments pack 'our-default-argpack' : ['foobar']
-
-
     [step::our-step1]     Script : ./tests/scripts/echo_normal.sh
-
-
     [step::our-step1]     Running command:
-
-
     [step::our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows why "not more" args? foobar
-
-
     [step::our-step1]     ***************START our-step1***************
-
-
     
-
-
     why not more args? foobar
-
-
     TEST echo_normal.sh PASS
-
-
     
-
-
     [step::our-step1]     ***************STOP our-step1 ***************
-
-
     [step::our-step1]   Finished submitting step our-step1
-
-
     
-
-
     [test::our-test]    Checking remaining steps...
-
-
     [test::our-test]    No remaining steps, test submission complete
-
-
     [test::our-test]    Outputting results...
-
-
     [step::our-step0]   Results for our-step0
-
-
     [step::our-step0]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
-
-
     [step::our-step0]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step0]     [SUCCESS]
-
-
     [step::our-step1]   Results for our-step1
-
-
     [step::our-step1]     Opening log file /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step1.log
-
-
     [step::our-step1]     Checking last line for success <KEY PHRASE> of format 'TEST ((?:\w+|[.-])+) PASS'
-
-
     [step::our-step1]     [SUCCESS]
-
-
     [test::our-test]    Writing relevant logfiles to view in master log file : 
-
-
     [test::our-test]      /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.log
-
-
     [test::our-test]    [SUCCESS] : Test our-test completed successfully
 
 

--- a/tutorials/sanitizer.py
+++ b/tutorials/sanitizer.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+
+nbFile = sys.argv[1]
+nbInput = open( nbFile, "r" )
+nbData = json.load( nbInput )
+nbInput.close()
+
+
+for cell in nbData["cells"] :
+  if cell["cell_type"] == "code" and "outputs" in cell and len( cell["outputs"] ) > 1 and cell["outputs"][0]["output_type"] == "stream" :
+    # these are all dict entries
+    cell["outputs"][0]["text"] = [ badout["text"][0] for badout in cell["outputs"] ]
+    
+    cell["outputs"] = cell["outputs"][0:1]
+
+
+nbOutput = open( nbFile, "w" )
+nbData = json.dump( nbData, nbOutput, indent=2 )
+nbOutput.close()


### PR DESCRIPTION
Jupyter `nbconvert` messes up output if using built-in execute  with all code output from stdout as separate entries resulting in horrible looking markdown output with double spacing. Hardly anything online exists about this so no solution for single call, instead break out into multiple with an additional sanitizer.