### PR TITLE
Use a more flexible regex for filenames when using internal keyphrase

### DIFF
--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -262,7 +262,7 @@ class Suite( SubmitAction ) :
 
     # Make our current key check for multitest pass
     self.log( "Setting keyphrase for passing to internally defined one")
-    hpcJoinOpts.key = "\[file::(\w+)\][ ]*\[SUCCESS\] : All tests passed"
+    hpcJoinOpts.key = "\[file::(.*?)\][ ]*\[SUCCESS\] : All tests passed"
 
     hpcJoinTest = Test( "joinHPC_" + "_".join( tests ), testDict, self.submitOptions_, hpcJoinOpts, parent=self.ancestry(), rootDir=self.rootDir_ )
     # No argpacks


### PR DESCRIPTION
When test filenames have `-` or any other valid filename that is not covered by `\w+` the HPC join tests will report false failure, though actual evaluation of the tests themselves will cause a successful run.

To ensure output is consistent with all test results the following internal regex should be changed to an expression that is more tolerant to user file naming.