### PR TITLE
Parse error handling

### DIFF
--- a/.ci/Step.py
+++ b/.ci/Step.py
@@ -49,21 +49,29 @@ class Step( SubmitAction ):
 
   def parseSpecificOptions( self ) :
 
+    optionKeys = []
+
     key = "command"
+    optionKeys.append( key )
     if key in self.options_ :
       self.command_ = self.options_[ key ]
 
     key = "arguments"
+    optionKeys.append( key )
     if key in self.options_ :
       self.arguments_ = self.options_[ key ]
 
     key = "dependencies"
+    optionKeys.append( key )
     if key in self.options_ :
       for depStep, depType in self.options_[ key ].items() :
         self.dependencies_[ depStep ] = Step.DependencyType( depType )
 
     # Now set things manually
     self.submitOptions_ = self.submitOptions_.selectHostSpecificSubmitOptions( host=self.globalOpts_.forceFQDN, print=self.log )
+
+    # return valid keys
+    return optionKeys
 
   def validate( self ) :
     self.submitOptions_.validate( print=self.log )

--- a/.ci/SubmitAction.py
+++ b/.ci/SubmitAction.py
@@ -44,6 +44,7 @@ class SubmitAction( ) :
     contents = output.getvalue()
     output.close()
     print( self.label_ + self.labelIndentation_ * self.labelLevel_ + contents, flush=True )
+    return self.label_ + self.labelIndentation_ * self.labelLevel_ + contents
   
   def log_push( self, levels=1 ) :
     self.labelLevel_ += levels

--- a/.ci/SubmitCommon.py
+++ b/.ci/SubmitCommon.py
@@ -20,3 +20,13 @@ def recursiveUpdate( dest, source ):
       dest[k] = v
   return dest
 
+# An exception type to handle parse errors
+class SubmitParseException( Exception ) :
+  def __init__( self, msg ) :
+    super( Exception, self ).__init__( msg )
+
+# An exception type to handle parse errors parents
+class SubmitParentParseException( Exception ) :
+  def __init__( self, msg ) :
+    super( Exception, self ).__init__( msg )
+

--- a/.ci/SubmitOptions.py
+++ b/.ci/SubmitOptions.py
@@ -50,55 +50,64 @@ class SubmitOptions( ) :
     self.parse( origin=origin, print=print )
 
   def parse( self, print=print, origin=None ):
-    submitKeys = []
+    try :
+      submitKeys = []
 
-    key = "working_directory"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.workingDirectory_ = self.submit_[ key ]
-    
-    key = "queue"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.queue_ = self.submit_[ key ]
-    
-    key = "timelimit"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.timelimit_ = self.submit_[ key ]
-    
-    key = "wait"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.wait_ = self.submit_[ key ]
+      key = "working_directory"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.workingDirectory_ = self.submit_[ key ]
+      
+      key = "queue"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.queue_ = self.submit_[ key ]
+      
+      key = "timelimit"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.timelimit_ = self.submit_[ key ]
+      
+      key = "wait"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.wait_ = self.submit_[ key ]
 
-    key = "hpc_arguments"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.hpcArguments_.update( HpcArgpacks( self.submit_[ key ], origin ), print )
-    
-    key = "arguments"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      self.arguments_.update( SubmitArgpacks( self.submit_[ key ], origin ), print )
-    
-    # Allow parsing of per-action submission
-    key = "submission"
-    submitKeys.append( key )
-    if key in self.submit_ :
-      if not self.lockSubmitType_ :
-        self.submitType_ = sc.SubmissionType( self.submit_[ key ] )
+      key = "hpc_arguments"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.hpcArguments_.update( HpcArgpacks( self.submit_[ key ], origin ), print )
+      
+      key = "arguments"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        self.arguments_.update( SubmitArgpacks( self.submit_[ key ], origin ), print )
+      
+      # Allow parsing of per-action submission
+      key = "submission"
+      submitKeys.append( key )
+      if key in self.submit_ :
+        if not self.lockSubmitType_ :
+          self.submitType_ = sc.SubmissionType( self.submit_[ key ] )
 
 
-    # Process all other keys as host-specific options
-    for key, value in self.submit_.items() :
-      if key not in submitKeys :
-        if not self.isHostSpecific_ :
-          # ok to parse
-          self.hostSpecificOptions_[ key ] = SubmitOptions( value, isHostSpecific=True )
-          self.hostSpecificOptions_[ key ].parse( origin=origin )
-        else :
-          print( "Warning: Host-specific options cannot have sub-host-specific options" )
+      # Process all other keys as host-specific options
+      for key, value in self.submit_.items() :
+        if key not in submitKeys :
+          if not self.isHostSpecific_ :
+            # ok to parse
+            self.hostSpecificOptions_[ key ] = SubmitOptions( value, isHostSpecific=True )
+            self.hostSpecificOptions_[ key ].parse( origin=origin )
+          else :
+            print( "Warning: Host-specific options cannot have sub-host-specific options" )
+    except Exception as e :
+      msg = print( "ERROR! Failed parse for submit options : {{ {fields} }}".format( fields=str( self.submit_ ) )
+            )
+      if msg is None :
+        # just re-raise, we don't have enough info
+        raise e
+      else :
+        raise sc.SubmitParseException( msg ) from e
 
 
   # Updates and overrides current with values from rhs if they exist

--- a/.ci/Test.py
+++ b/.ci/Test.py
@@ -30,8 +30,10 @@ class Test( SubmitAction ):
     super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
 
   def parseSpecificOptions( self ) :
+    optionKeys = []
 
     key = "steps"
+    optionKeys.append( key )
     if key in self.options_ :
       if key == "results" :
         msg = "Keyword 'results' not allowed as step name, reason: reserved"
@@ -51,6 +53,8 @@ class Test( SubmitAction ):
     
     # Now that steps are fully parsed, attempt to organize dependencies
     Step.sortDependencies( self.steps_ )
+
+    return optionKeys
 
   def validate( self ) :
     for step in self.steps_.values() :

--- a/.ci/example.json
+++ b/.ci/example.json
@@ -19,7 +19,6 @@
         "submit_options" :
         { 
           "working_directory" : "./tests",
-          "resources"         : "1:ncpus=1",
           "timelimit"         : "00:01:00",
           "cheyenne" :
           {
@@ -37,7 +36,6 @@
        { 
         "submit_options" :
         { 
-          "resources"         : "1:ncpus=1",
           "timelimit"         : "00:05:00",
           "cheyenne" :
           {
@@ -53,7 +51,6 @@
         "submit_options" :
         { 
           "working_directory" : "./tests",
-          "resources"         : "1:ncpus=1",
           "cheyenne" :
           {
             "submission"        : "LOCAL"
@@ -74,7 +71,6 @@
         "submit_options" :
         { 
           "working_directory" : "./tests",
-          "resources"         : "1:ncpus=1",
           "timelimit"         : "00:01:00",
           "cheyenne" :
           {
@@ -92,7 +88,6 @@
        { 
         "submit_options" :
         { 
-          "resources"         : "1:ncpus=1",
           "timelimit"         : "00:05:00",
           "cheyenne" :
           {
@@ -108,7 +103,6 @@
         "submit_options" :
         { 
           "working_directory" : "./tests",
-          "resources"         : "1:ncpus=1",
           "cheyenne" :
           {
             "submission"        : "LOCAL"

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -53,6 +53,8 @@ class Suite( SubmitAction ) :
       if test != "submit_options" :
         self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
 
+    return [] # all keys are valid
+
   # Take immediate test return and output what happened
   def reportErrs( self, test, testLog ) :
     if testLog["success"] :

--- a/tutorials/AdvancedRunOption_join_hpc.ipynb
+++ b/tutorials/AdvancedRunOption_join_hpc.ipynb
@@ -27,7 +27,7 @@
    "id": "099ebede-a119-426f-8364-0e63385303ed",
    "metadata": {},
    "source": [
-    "Advanced usage of the <ins>run script</ins> command line option `-j` will be the focus of this tutorial :"
+    "Advanced usage of the <ins>run script</ins> command line option `-j`/`--joinHPC` will be the focus of this tutorial :"
    ]
   },
   {

--- a/tutorials/AdvancedRunOption_join_hpc.md
+++ b/tutorials/AdvancedRunOption_join_hpc.md
@@ -13,7 +13,7 @@ print( "Working from " + notebookDirectory )
     Working from /home/runner/work/hpc-workflows/hpc-workflows/tutorials
 
 
-Advanced usage of the <ins>run script</ins> command line option `-j` will be the focus of this tutorial :
+Advanced usage of the <ins>run script</ins> command line option `-j`/`--joinHPC` will be the focus of this tutorial :
 
 
 ```bash
@@ -26,7 +26,7 @@ $1/../.ci/runner.py $1/../our-config.json -h | \
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     usage: runner.py [-h] [-t TESTS [TESTS ...]] [-s {PBS,SLURM,LOCAL}]
                      [-a ACCOUNT] [-d DIROFFSET] [-j [JOINHPC]]
                      [-alt [ALTDIRS ...]] [-l LABELLENGTH] [-g GLOBALPREFIX]
@@ -157,7 +157,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -182,7 +182,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0]       Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Doing dry-run, no ouptut
@@ -296,7 +296,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -fs -
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -321,7 +321,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -fs -
     [step::our-config.our-test0.our-step0]      Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.our-test0.our-step0]    Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test0.our-step0]    Running command:
-    [step::our-config.our-test0.our-step0]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test0.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test0.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test0.our-step0]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test0.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test0.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test0.our-step0]    ***************START our-step0***************
     
     [step::our-config.our-test0.our-step0]    Doing dry-run, no ouptut
@@ -359,7 +359,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -fs -
     [step::our-config.our-test1.our-step1]      Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.our-test1.our-step1]    Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test1.our-step1]    Running command:
-    [step::our-config.our-test1.our-step1]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test1.our-step1 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test1.our-step1.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test1.our-step1]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test1.our-step1 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test1.our-step1.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test1.our-step1]    ***************START our-step1***************
     
     [step::our-config.our-test1.our-step1]    Doing dry-run, no ouptut
@@ -397,7 +397,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -fs -
     [step::our-config.our-test2.our-step2]      Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.our-test2.our-step2]    Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test2.our-step2]    Running command:
-    [step::our-config.our-test2.our-step2]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test2.our-step2 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test2.our-step2.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test2.our-step2]      qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test2.our-step2 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test2.our-step2.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test2.our-step2]    ***************START our-step2***************
     
     [step::our-config.our-test2.our-step2]    Doing dry-run, no ouptut
@@ -427,7 +427,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -492,7 +492,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Running command:
-    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=3:mem=96gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal --forceFQDN fv-az1536-455.clt0scp5daoehk2t4xy1kvnmsg.bx.internal.cloudapp.net
+    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=3:mem=96gb -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal --forceFQDN fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   *************** START submit  ***************
     
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Doing dry-run, no ouptut
@@ -536,7 +536,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -607,7 +607,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 -i -d
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Running command:
-    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:03:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 1 --threadpool 1 --inlineLocal --forceFQDN fv-az1536-455.clt0scp5daoehk2t4xy1kvnmsg.bx.internal.cloudapp.net
+    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=1:mem=32gb -l job_priority=economy -q main -l walltime=00:03:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 1 --threadpool 1 --inlineLocal --forceFQDN fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   *************** START submit  ***************
     
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Doing dry-run, no ouptut
@@ -683,7 +683,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 \
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -750,7 +750,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test0 our-test1 our-test2 \
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     Final argpack output for priority : '-l job_priority=premium'
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Running command:
-    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=1:mem=96gb -l job_priority=premium -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal --forceFQDN fv-az1536-455.clt0scp5daoehk2t4xy1kvnmsg.bx.internal.cloudapp.net
+    [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]     qsub -l select=1:mem=96gb -l job_priority=premium -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_our-test0_our-test1_our-test2.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_our-test0_our-test1_our-test2.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests our-test0 our-test1 our-test2 --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 1 --inlineLocal --forceFQDN fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   *************** START submit  ***************
     
     [step::our-config.joinHPC_our-test0_our-test1_our-test2.submit]   Doing dry-run, no ouptut
@@ -1008,7 +1008,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
     [file::our-config]                        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
@@ -1051,7 +1051,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
     [test::our-config.fullnode-double]          Calculating expected runtime of steps across 2 thread workers [threadpool size]
     [test::our-config.fullnode-double]            Simulating threadpool for 0:01:00
     [test::our-config.fullnode-double]              Calculate max instantaneous resources for this phase
-    [test::our-config.fullnode-double]                  Joining argpack '.*fullnode.*::select'  from [our-config, our-config.fullnode-double] into joinall
+    [test::our-config.fullnode-double]                  Joining argpack '.*fullnode.*::select'  from [our-config.fullnode-double, our-config] into joinall
     [test::our-config.fullnode-double]                  Joining argpack 'priority'              from [our-config] into joinall
     [test::our-config.fullnode-double]                Unsure how to operate on resources economy and economy together, defaulting to economy
     [test::our-config.fullnode-double]              [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
@@ -1097,7 +1097,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Running command:
-    [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     qsub -l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2 --forceFQDN fv-az1536-455.clt0scp5daoehk2t4xy1kvnmsg.bx.internal.cloudapp.net
+    [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     qsub -l select=10:mem=608gb:ncpus=640:mpiprocs=320 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2 --forceFQDN fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   *************** START submit  ***************
     
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Doing dry-run, no ouptut
@@ -1170,7 +1170,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
     [file::our-config]                        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
@@ -1213,7 +1213,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
     [test::our-config.fullnode-double]          Calculating expected runtime of steps across 2 thread workers [threadpool size]
     [test::our-config.fullnode-double]            Simulating threadpool for 0:01:00
     [test::our-config.fullnode-double]              Calculate max instantaneous resources for this phase
-    [test::our-config.fullnode-double]                  Joining argpack '.*fullnode.*::select'  from [our-config, our-config.fullnode-double] into joinall
+    [test::our-config.fullnode-double]                  Joining argpack '.*fullnode.*::select'  from [our-config.fullnode-double, our-config] into joinall
     [test::our-config.fullnode-double]                  Joining argpack 'priority'              from [our-config] into joinall
     [test::our-config.fullnode-double]                Unsure how to operate on resources economy and economy together, defaulting to economy
     [test::our-config.fullnode-double]              [PHASE 0] Resources for [      our-step0  our-step0-mpi ] : '-l select=4:mem=256gb:ncpus=256:mpiprocs=128 -l job_priority=economy', timelimit = 0:01:00
@@ -1261,7 +1261,7 @@ $1/../.ci/runner.py $1/../our-config.json -t quartnode-simple quartnode fullnode
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     Final argpack output for priority : '-l job_priority=economy'
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Script : /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Running command:
-    [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     qsub -l select=7:mem=128GB:ncpus=128:mpiprocs=128 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2 --forceFQDN fv-az1536-455.clt0scp5daoehk2t4xy1kvnmsg.bx.internal.cloudapp.net
+    [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]     qsub -l select=7:mem=128GB:ncpus=128:mpiprocs=128 -l job_priority=economy -q main -l walltime=00:01:00 -A WORKFLOWS -N our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit.log -- /home/runner/work/hpc-workflows/hpc-workflows/.ci/runner.py /home/runner/work/hpc-workflows/hpc-workflows/our-config.json --tests quartnode-simple quartnode fullnode-simple fullnode-double --submitType LOCAL --account WORKFLOWS --labelLength 32 --dryRun --key "TEST ((?:\w+|[.-])+) PASS" --pool 4 --threadpool 2 --forceFQDN fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   *************** START submit  ***************
     
     [step::our-config.joinHPC_quartnode-simple_quartnode_fullnode-simple_fullnode-double.submit]   Doing dry-run, no ouptut

--- a/tutorials/AdvancedTestConfig_host_specific.md
+++ b/tutorials/AdvancedTestConfig_host_specific.md
@@ -119,6 +119,9 @@ md( "```python\n##### From Step.py #####" +
     # Now set things manually
     self.submitOptions_ = self.submitOptions_.selectHostSpecificSubmitOptions( host=self.globalOpts_.forceFQDN, print=self.log )
 
+    # return valid keys
+    return optionKeys
+
   
 ##### From runner.py #####
 
@@ -148,7 +151,7 @@ $1/../.ci/runner.py $1/../our-config.json -h | \
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     usage: runner.py [-h] [-t TESTS [TESTS ...]] [-s {PBS,SLURM,LOCAL}]
                      [-a ACCOUNT] [-d DIROFFSET] [-j [JOINHPC]]
                      [-alt [ALTDIRS ...]] [-l LABELLENGTH] [-g GLOBALPREFIX]
@@ -211,7 +214,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -228,7 +231,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
     [step::our-config.our-test.our-step0-less-nodes]     From our-config adding arguments pack 'data_path' : ['-p', '/some/local/path/']
     [step::our-config.our-test.our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0-less-nodes]   Running command:
-    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /some/local/path/
+    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh tutorials.hpc-workflows.foobar.com /home/runner/work/hpc-workflows/hpc-workflows -p /some/local/path/
     [step::our-config.our-test.our-step0-less-nodes]   ***************START our-step0-less-nodes***************
     
     -p /some/local/path/
@@ -309,7 +312,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -326,7 +329,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
     [step::our-config.our-test.our-step0-less-nodes]     From our-config adding arguments pack 'data_path' : ['-p', '/opt/data/path']
     [step::our-config.our-test.our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0-less-nodes]   Running command:
-    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /opt/data/path
+    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh tutorials.hpc-workflows.foobar.com /home/runner/work/hpc-workflows/hpc-workflows -p /opt/data/path
     [step::our-config.our-test.our-step0-less-nodes]   ***************START our-step0-less-nodes***************
     
     -p /opt/data/path
@@ -427,7 +430,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -444,7 +447,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -ff tutorials.hpc-w
     [step::our-config.our-test.our-step0-less-nodes]     From our-config.our-test adding arguments pack 'data_path' : ['-p', '/home/user/data/path']
     [step::our-config.our-test.our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0-less-nodes]   Running command:
-    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -p /home/user/data/path
+    [step::our-config.our-test.our-step0-less-nodes]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh tutorials.hpc-workflows.foobar.com /home/runner/work/hpc-workflows/hpc-workflows -p /home/user/data/path
     [step::our-config.our-test.our-step0-less-nodes]   ***************START our-step0-less-nodes***************
     
     -p /home/user/data/path

--- a/tutorials/AdvancedTestConfig_hpc_argpacks.md
+++ b/tutorials/AdvancedTestConfig_hpc_argpacks.md
@@ -104,7 +104,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
     [file::our-config]                        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
@@ -130,7 +130,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -145,7 +145,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     
@@ -199,28 +199,28 @@ echo ""
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]   Error: Invalid submission options [Missing account on non-LOCAL submission]
-    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f1e7a297880>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': None, 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f1e7a2978e0>, 'union_parse': {'submission': 'PBS'}}
+    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f90fbef7a90>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': None, 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f90fbef7af0>, 'union_parse': {'submission': 'PBS'}}
     Traceback (most recent call last):
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 715, in <module>
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 717, in <module>
         main()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 709, in main
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 711, in main
         success, tests, logs = runSuite( options )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 518, in runSuite
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 520, in runSuite
         success, logs = testSuite.run( options.tests )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 433, in run
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 435, in run
         self.tests_[test].validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 61, in validate
         step.validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 77, in validate
         self.submitOptions_.validate( print=self.log )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 158, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 167, in validate
         raise Exception( errMsg )
     Exception: Error: Invalid submission options [Missing account on non-LOCAL submission]
-    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f1e7a297880>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': None, 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f1e7a2978e0>, 'union_parse': {'submission': 'PBS'}}
+    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f90fbef7a90>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': None, 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f90fbef7af0>, 'union_parse': {'submission': 'PBS'}}
     
 
 
@@ -257,28 +257,28 @@ echo ""
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]   Error: Invalid submission options [Missing queue on non-LOCAL submission]
-    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f68b9cff880>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': 'WORKFLOWS', 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f68b9cff8e0>, 'union_parse': {'submission': 'PBS'}}
+    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7fcabc6afa90>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': 'WORKFLOWS', 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7fcabc6afaf0>, 'union_parse': {'submission': 'PBS'}}
     Traceback (most recent call last):
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 715, in <module>
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 717, in <module>
         main()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 709, in main
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 711, in main
         success, tests, logs = runSuite( options )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 518, in runSuite
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 520, in runSuite
         success, logs = testSuite.run( options.tests )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 433, in run
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 435, in run
         self.tests_[test].validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 61, in validate
         step.validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 77, in validate
         self.submitOptions_.validate( print=self.log )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 158, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 167, in validate
         raise Exception( errMsg )
     Exception: Error: Invalid submission options [Missing queue on non-LOCAL submission]
-    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7f68b9cff880>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': 'WORKFLOWS', 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7f68b9cff8e0>, 'union_parse': {'submission': 'PBS'}}
+    {'working_directory': None, 'queue': None, 'hpc_arguments': <HpcArgpacks.HpcArgpacks object at 0x7fcabc6afa90>, 'timelimit': None, 'wait': None, 'submitType': <SubmissionType.PBS: 'PBS'>, 'lockSubmitType': False, 'debug': None, 'account': 'WORKFLOWS', 'name': 'our-config.our-test.our-step0', 'dependencies': None, 'arguments': <SubmitArgpacks.SubmitArgpacks object at 0x7fcabc6afaf0>, 'union_parse': {'submission': 'PBS'}}
     
 
 
@@ -319,7 +319,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -334,7 +334,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       qsub -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       qsub -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Doing dry-run, no ouptut
@@ -460,7 +460,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -479,7 +479,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0]       Final argpack output for node_select : '-l'
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       qsub -l -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       qsub -l -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Doing dry-run, no ouptut
@@ -545,7 +545,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -565,7 +565,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0]       Final argpack output for select : '-lselect=1'
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       qsub -lselect=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       qsub -lselect=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Doing dry-run, no ouptut
@@ -656,7 +656,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       "our-test" : { "steps" : { "our-step0" : { "command" : "./tests/scripts/echo_normal.sh" } } }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -676,7 +676,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0]       Final argpack output for select : '-l select=1'
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0 -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Doing dry-run, no ouptut
@@ -774,31 +774,31 @@ echo ""
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [test::our-config.our-test]             Argument pack select at our-config.our-test '.*more-nodes.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
     Traceback (most recent call last):
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 715, in <module>
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 717, in <module>
         main()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 709, in main
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 711, in main
         success, tests, logs = runSuite( options )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 510, in runSuite
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 512, in runSuite
         testSuite = Suite( 
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 41, in __init__
         super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 32, in __init__
         self.parse()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 65, in parse
-        self.parseSpecificOptions()
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 67, in parse
+        optionKeys = self.parseSpecificOptions()
       File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 54, in parseSpecificOptions
         self.tests_[ test ] = Test( test, testDict, self.submitOptions_, self.globalOpts_, parent=self.ancestry(), rootDir=self.rootDir_ )
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 30, in __init__
         super().__init__( name, options, defaultSubmitOptions, globalOpts, parent, rootDir )
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 32, in __init__
         self.parse()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 60, in parse
-        self.submitOptions_.update( SubmitOptions( self.options_[ key ], origin=self.ancestry(), print=self.log ), print=self.log )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 124, in update
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitAction.py", line 62, in parse
+        self.submitOptions_.update( SubmitOptions( self.options_[ submitKey ], origin=self.ancestry(), print=self.log ), print=self.log )
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 133, in update
         if rhs.hpcArguments_.arguments_         : self.hpcArguments_.update( rhs.hpcArguments_, print=print )    
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/HpcArgpacks.py", line 35, in update
         self.nestedArguments_[key].update( rhs.nestedArguments_[key], print )
@@ -874,7 +874,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -894,7 +894,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i -dry -a WORKFLOWS
     [step::our-config.our-test.our-step0-less-nodes]     Final argpack output for .*less-nodes.*::select : '-l select=1'
     [step::our-config.our-test.our-step0-less-nodes]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0-less-nodes]   Running command:
-    [step::our-config.our-test.our-step0-less-nodes]     qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0-less-nodes -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0-less-nodes]     qsub -l select=1 -q economy -l walltime=00:01:00 -A WORKFLOWS -N our-config.our-test.our-step0-less-nodes -j oe -o /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0-less-nodes.log -- /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0-less-nodes]   ***************START our-step0-less-nodes***************
     
     [step::our-config.our-test.our-step0-less-nodes]   Doing dry-run, no ouptut
@@ -977,24 +977,24 @@ echo ""
       }
     }
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0-less-nodes] Argument pack select at our-config.our-test '.*our.*::select' name conflict with '.*less-nodes.*::select', declared at our-config
     Traceback (most recent call last):
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 715, in <module>
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 717, in <module>
         main()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 709, in main
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 711, in main
         success, tests, logs = runSuite( options )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 518, in runSuite
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 520, in runSuite
         success, logs = testSuite.run( options.tests )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 433, in run
+      File "/home/runner/work/hpc-workflows/hpc-workflows/tutorials/../.ci/runner.py", line 435, in run
         self.tests_[test].validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 57, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Test.py", line 61, in validate
         step.validate()
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 69, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/Step.py", line 77, in validate
         self.submitOptions_.validate( print=self.log )
-      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 161, in validate
+      File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/SubmitOptions.py", line 170, in validate
         self.hpcArguments_.selectAncestrySpecificSubmitArgpacks( print=print )
       File "/home/runner/work/hpc-workflows/hpc-workflows/.ci/HpcArgpacks.py", line 69, in selectAncestrySpecificSubmitArgpacks
         finalHpcArgpacks.validate( print=print )

--- a/tutorials/AdvancedTestConfig_regex_argpacks.md
+++ b/tutorials/AdvancedTestConfig_regex_argpacks.md
@@ -150,7 +150,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -167,7 +167,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.send-step0]     From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
     [step::our-config.regex-test.send-step0]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.send-step0]   Running command:
-    [step::our-config.regex-test.send-step0]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows Hello! "[send] "
+    [step::our-config.regex-test.send-step0]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows Hello! "[send] "
     [step::our-config.regex-test.send-step0]   ***************START send-step0***************
     
     Hello! [send]
@@ -176,16 +176,16 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.send-step0]   ***************STOP send-step0***************
     [step::our-config.regex-test.send-step0] Finished submitting step send-step0
     
-    [test::our-config.regex-test]           Checking remaining steps...
     [step::our-config.regex-test.recv-step1] Preparing working directory
     [step::our-config.regex-test.recv-step1]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
+    [test::our-config.regex-test]           Checking remaining steps...
     [step::our-config.regex-test.recv-step1]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.regex-test.recv-step1] Submitting step recv-step1...
     [step::our-config.regex-test.recv-step1]   Gathering argument packs...
     [step::our-config.regex-test.recv-step1]     From our-config.regex-test adding arguments pack '.*recv.*::recv_prefix' : ['[recv] ']
     [step::our-config.regex-test.recv-step1]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.recv-step1]   Running command:
-    [step::our-config.regex-test.recv-step1]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Hello back!" "[recv] "
+    [step::our-config.regex-test.recv-step1]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows "Hello back!" "[recv] "
     [step::our-config.regex-test.recv-step1]   ***************START recv-step1***************
     
     Hello back! [recv]
@@ -202,7 +202,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.send-step2]     From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
     [step::our-config.regex-test.send-step2]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.send-step2]   Running command:
-    [step::our-config.regex-test.send-step2]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Ping 1" "[send] "
+    [step::our-config.regex-test.send-step2]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows "Ping 1" "[send] "
     [step::our-config.regex-test.send-step2]   ***************START send-step2***************
     
     Ping 1 [send]
@@ -219,7 +219,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.send-step3]     From our-config.regex-test adding arguments pack '.*send.*::send_prefix' : ['[send] ']
     [step::our-config.regex-test.send-step3]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.send-step3]   Running command:
-    [step::our-config.regex-test.send-step3]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Ping 2" "[send] "
+    [step::our-config.regex-test.send-step3]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows "Ping 2" "[send] "
     [step::our-config.regex-test.send-step3]   ***************START send-step3***************
     
     Ping 2 [send]
@@ -236,7 +236,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.recv-step4]     From our-config.regex-test adding arguments pack '.*recv.*::recv_prefix' : ['[recv] ']
     [step::our-config.regex-test.recv-step4]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.recv-step4]   Running command:
-    [step::our-config.regex-test.recv-step4]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows "Pings received" "[recv] "
+    [step::our-config.regex-test.recv-step4]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows "Pings received" "[recv] "
     [step::our-config.regex-test.recv-step4]   ***************START recv-step4***************
     
     Pings received [recv]
@@ -380,7 +380,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -398,7 +398,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-omp-fp32-dbg]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag' : ['--omp']
     [step::our-config.regex-test.build-omp-fp32-dbg]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-omp-fp32-dbg]   Running command:
-    [step::our-config.regex-test.build-omp-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-dbg -d --omp
+    [step::our-config.regex-test.build-omp-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-dbg -d --omp
     [step::our-config.regex-test.build-omp-fp32-dbg]   ***************START build-omp-fp32-dbg***************
     
     -o build-omp-fp32-dbg -d --omp
@@ -409,6 +409,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     
     [step::our-config.regex-test.build-omp-fp32-ftA] Preparing working directory
     [step::our-config.regex-test.build-omp-fp32-ftA]   Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
+    [test::our-config.regex-test]           Checking remaining steps...
     [step::our-config.regex-test.build-omp-fp32-ftA]   Current directory : /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.regex-test.build-omp-fp32-ftA] Submitting step build-omp-fp32-ftA...
     [step::our-config.regex-test.build-omp-fp32-ftA]   Gathering argument packs...
@@ -416,10 +417,9 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-omp-fp32-ftA]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
     [step::our-config.regex-test.build-omp-fp32-ftA]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-omp-fp32-ftA]   Running command:
-    [step::our-config.regex-test.build-omp-fp32-ftA]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftA -a --omp
+    [step::our-config.regex-test.build-omp-fp32-ftA]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftA -a --omp
     [step::our-config.regex-test.build-omp-fp32-ftA]   ***************START build-omp-fp32-ftA***************
     
-    [test::our-config.regex-test]           Checking remaining steps...
     -o build-omp-fp32-ftA -a --omp
     TEST echo_normal.sh PASS
     
@@ -436,7 +436,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-omp-fp32-ftAB]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
     [step::our-config.regex-test.build-omp-fp32-ftAB]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-omp-fp32-ftAB]   Running command:
-    [step::our-config.regex-test.build-omp-fp32-ftAB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftAB -a -b --omp
+    [step::our-config.regex-test.build-omp-fp32-ftAB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftAB -a -b --omp
     [step::our-config.regex-test.build-omp-fp32-ftAB]   ***************START build-omp-fp32-ftAB***************
     
     -o build-omp-fp32-ftAB -a -b --omp
@@ -455,7 +455,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-omp-fp32-ftBC]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
     [step::our-config.regex-test.build-omp-fp32-ftBC]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-omp-fp32-ftBC]   Running command:
-    [step::our-config.regex-test.build-omp-fp32-ftBC]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftBC -b -c --omp
+    [step::our-config.regex-test.build-omp-fp32-ftBC]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp32-ftBC -b -c --omp
     [step::our-config.regex-test.build-omp-fp32-ftBC]   ***************START build-omp-fp32-ftBC***************
     
     -o build-omp-fp32-ftBC -b -c --omp
@@ -474,7 +474,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-omp-fp64-ftB]     From our-config.regex-test adding arguments pack '.*omp.*::omp_flag'       : ['--omp']
     [step::our-config.regex-test.build-omp-fp64-ftB]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-omp-fp64-ftB]   Running command:
-    [step::our-config.regex-test.build-omp-fp64-ftB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp64-ftB -b --double --omp
+    [step::our-config.regex-test.build-omp-fp64-ftB]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-omp-fp64-ftB -b --double --omp
     [step::our-config.regex-test.build-omp-fp64-ftB]   ***************START build-omp-fp64-ftB***************
     
     -o build-omp-fp64-ftB -b --double --omp
@@ -492,7 +492,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-mpi-fp32-dbg]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag' : ['--mpi']
     [step::our-config.regex-test.build-mpi-fp32-dbg]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-mpi-fp32-dbg]   Running command:
-    [step::our-config.regex-test.build-mpi-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32-dbg -d --mpi
+    [step::our-config.regex-test.build-mpi-fp32-dbg]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32-dbg -d --mpi
     [step::our-config.regex-test.build-mpi-fp32-dbg]   ***************START build-mpi-fp32-dbg***************
     
     -o build-mpi-fp32-dbg -d --mpi
@@ -509,7 +509,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-mpi-fp32]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag' : ['--mpi']
     [step::our-config.regex-test.build-mpi-fp32]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-mpi-fp32]   Running command:
-    [step::our-config.regex-test.build-mpi-fp32]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32 --mpi
+    [step::our-config.regex-test.build-mpi-fp32]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp32 --mpi
     [step::our-config.regex-test.build-mpi-fp32]   ***************START build-mpi-fp32***************
     
     -o build-mpi-fp32 --mpi
@@ -527,7 +527,7 @@ $1/../.ci/runner.py $1/../our-config.json -t regex-test --forceSingle --inlineLo
     [step::our-config.regex-test.build-mpi-fp64]     From our-config.regex-test adding arguments pack '.*mpi.*::mpi_flag'   : ['--mpi']
     [step::our-config.regex-test.build-mpi-fp64]   Script : ./tests/scripts/echo_normal.sh
     [step::our-config.regex-test.build-mpi-fp64]   Running command:
-    [step::our-config.regex-test.build-mpi-fp64]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp64 --double --mpi
+    [step::our-config.regex-test.build-mpi-fp64]     /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows -o build-mpi-fp64 --double --mpi
     [step::our-config.regex-test.build-mpi-fp64]   ***************START build-mpi-fp64***************
     
     -o build-mpi-fp64 --double --mpi

--- a/tutorials/BasicTestConfig.md
+++ b/tutorials/BasicTestConfig.md
@@ -214,7 +214,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
     [file::our-config]                        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
@@ -242,7 +242,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test --forceSingle # we could s
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
     [file::our-config]                        Running from root directory /home/runner/work/hpc-workflows/hpc-workflows
@@ -256,7 +256,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test --forceSingle # we could s
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     [step::our-config.our-test.our-step0]     Local step will be redirected to logfile /home/runner/work/hpc-workflows/hpc-workflows/our-config.our-test.our-step0.log
@@ -285,7 +285,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -300,7 +300,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     
@@ -374,7 +374,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -389,7 +389,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows foobar
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     foobar
@@ -471,7 +471,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -486,7 +486,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
     [step::our-config.our-test.our-step0]   Submitting step our-step0...
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows foobar
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     foobar
@@ -503,7 +503,7 @@ $1/../.ci/runner.py $1/../our-config.json -t our-test -fs -i # using shorthand o
     [step::our-config.our-test.our-step1]   Submitting step our-step1...
     [step::our-config.our-test.our-step1]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step1]     Running command:
-    [step::our-config.our-test.our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows why "not more" args?
+    [step::our-config.our-test.our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows why "not more" args?
     [step::our-config.our-test.our-step1]     ***************START our-step1***************
     
     why not more args?
@@ -610,7 +610,7 @@ rm $1/../our-config.json $1/../*.log
 ```
 
     Using Python version : 
-    3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
+    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
     Inline stdout for steps requested, but steps' threadpool is greater than 1 - forcing threadpool to size 1 (serial)
     [file::our-config]                      Root directory is : /home/runner/work/hpc-workflows/hpc-workflows
     [file::our-config]                      Preparing working directory
@@ -627,7 +627,7 @@ rm $1/../our-config.json $1/../*.log
     [step::our-config.our-test.our-step0]       From our-config.our-test adding arguments pack 'our-default-argpack' : ['foobar']
     [step::our-config.our-test.our-step0]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step0]     Running command:
-    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows foobar foobar
+    [step::our-config.our-test.our-step0]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows foobar foobar
     [step::our-config.our-test.our-step0]     ***************START our-step0***************
     
     foobar foobar
@@ -646,7 +646,7 @@ rm $1/../our-config.json $1/../*.log
     [step::our-config.our-test.our-step1]       From our-config.our-test adding arguments pack 'our-default-argpack' : ['foobar']
     [step::our-config.our-test.our-step1]     Script : ./tests/scripts/echo_normal.sh
     [step::our-config.our-test.our-step1]     Running command:
-    [step::our-config.our-test.our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh /home/runner/work/hpc-workflows/hpc-workflows why "not more" args? foobar
+    [step::our-config.our-test.our-step1]       /home/runner/work/hpc-workflows/hpc-workflows/tests/scripts/echo_normal.sh fv-az842-452.yhlsagsewx4upp3hyc34bwbk4e.cx.internal.cloudapp.net /home/runner/work/hpc-workflows/hpc-workflows why "not more" args? foobar
     [step::our-config.our-test.our-step1]     ***************START our-step1***************
     
     why not more args? foobar


### PR DESCRIPTION
Add detailed error handling of parse failure where they can be detected (non-user defined fields)

For parsing events where the scope may not be known, use a two-phase exception system to raise the exception and then get the parent caller to provide additional context. Once these two exceptions are raised, no others are raised to avoid overly redundant info.