### PR TITLE
Reset current directory after test completion

### DIFF
--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -363,6 +363,12 @@ class Suite( SubmitAction ) :
       for testIdx, opt in enumerate( individualTestOpts ) :
         opt.testsConfig = testDirs[testIdx] + "/" + os.path.basename( self.globalOpts_.testsConfig )
 
+      if testDirs :
+        self.log_push()
+        for testIdx, opt in enumerate( individualTestOpts ) :
+          self.log( "Test [{test}] will run {config} from {cwd}".format( test=opt.tests[0], config=opt.testsConfig, cwd=os.getcwd() ) )
+        self.log_pop()
+
     self.log_pop()
 
     self.log( "Spawning process pool of size {0} to perform {1} tests".format( self.globalOpts_.pool, len(tests) ) )


### PR DESCRIPTION
When running multiple tests with mapped relative directories, the working directory will be changed to the mapped directory. However, if running in a process pool, the next test to pick up a worker that has already run with a different working directory will start in that wrong directory and thus the relative directory change will not be executed from the expected location.

To ensure processes in a pool always hand off at a known directory the current directory is stashed and subsequently popped after testing, regardless of test outcome.