### PR TITLE
Ensure that timelimits for joined jobs takes priority over defaults

### DIFF
--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -252,8 +252,12 @@ class Suite( SubmitAction ) :
     stepDict = {
                   "submit_options" : 
                   {
-                    "submission" : hpcSubmit[0],
-                    "timelimit"  : maxTimelimitStr
+                    self.globalOpts_.forceFQDN :
+                    {
+                      # Make this a host-specific so that it has priority
+                      "submission" : hpcSubmit[0],
+                      "timelimit"  : maxTimelimitStr
+                    }
                   },
                   "command"   : ABS_FILEPATH,
                   "arguments" : args


### PR DESCRIPTION
When a host-specific set of submit options is given at the top-level, this is effectively "derived" for all tests and steps created including the in situ one created during joining of jobs. This results in a joined job calcuating a new required timelimit of N but at submission time the value being overwritten by the previous host-specific value M. This is especially important for joined jobs where the calcuated timelimit MUST be correct and cannot rely on defaults if provided.

The changes place all possible values able to be provided in a host-specific submit option block inside one using the current host, whether manually provided or queried.