### PR TITLE
Add support for primitive json comments

### DIFF
--- a/.ci/JSONCDecoder.py
+++ b/.ci/JSONCDecoder.py
@@ -1,0 +1,12 @@
+# https://stackoverflow.com/a/72168909
+import json
+from typing import Any
+class JSONCDecoder( json.JSONDecoder ):
+  def __init__( self, **kw ) :
+    super().__init__( **kw )
+  
+  def decode( self, s : str ) -> Any :
+    # Sanitize the input string for leading // comments ONLY and replace with
+    # blank line so that line numbers are preserved
+    s = '\n'.join( l if not l.lstrip().startswith( "//" ) else "" for l in s.split( '\n' ) )
+    return super().decode( s )

--- a/.ci/runner.py
+++ b/.ci/runner.py
@@ -12,7 +12,7 @@ from multiprocessing import Pool
 from contextlib import redirect_stdout
 from datetime import timedelta
 
-
+import JSONCDecoder
 import SubmitCommon as sc
 
 from SubmitAction   import SubmitAction
@@ -518,7 +518,7 @@ def runSuite( options ) :
       with redirect_stdout( redirect ) :
         testSuite = Suite( 
                           basename,
-                          json.load( fp ),
+                          json.load( fp, cls=JSONCDecoder.JSONCDecoder ),
                           opts,
                           options,
                           parent=options.globalPrefix,
@@ -529,13 +529,13 @@ def runSuite( options ) :
         #   print( options.message )
   else :
     testSuite = Suite( 
-                          basename,
-                          json.load( fp ),
-                          opts,
-                          options,
-                          parent=options.globalPrefix,
-                          rootDir=root
-                          )
+                      basename,
+                      json.load( fp, cls=JSONCDecoder.JSONCDecoder ),
+                      opts,
+                      options,
+                      parent=options.globalPrefix,
+                      rootDir=root
+                      )
     success, logs = testSuite.run( options.tests )
     # if success and options.message :
     #   print( options.message ) 


### PR DESCRIPTION
To provide some support for comments within the test configs a simple JSON with comments decoder class has been introduced.

This only provides support for leading // style comments in an effort to remain lightweight and work with native Python installs, no dependencies on external packages. This should prove sufficient to allow a modicum of annotation to test configs.